### PR TITLE
Add all dependencies to .#run-test app

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,13 +130,17 @@
           program = pkgs.lib.getExe (self.lib.${system}.buildLockFile contents);
         };
 
-        apps.run-test =
-          let testScript = pkgs.writeShellApplication {
+        apps.run-test = let
+          testScript = pkgs.writeShellApplication {
             name = "test-templates";
-            runtimeInputs = [ inputs.nickel.packages."${system}".nickel-lang-cli ];
+            runtimeInputs = [
+              inputs.nickel.packages."${system}".nickel-lang-cli
+              pkgs.parallel
+              pkgs.gnused
+            ];
             text = builtins.readFile ./run-test.sh;
-          }; in
-        {
+          };
+        in {
           type = "app";
           program = pkgs.lib.getExe testScript;
         };


### PR DESCRIPTION
Allows to run without devshell and ensures it works on Darwin, where sed's `-i` option works differently.
