### PR TITLE
Autogenerate nickel.lock.ncl

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,9 +28,7 @@
         welcomeText = ''
           You have created a devshell that is built using nickel!
 
-          First run `nix run .#regenerate-lockfile` to fill `nickel.lock.ncl` with proper references.
-
-          Then run `nix develop` to enter the dev shell.
+          You can run `nix develop` to enter the dev shell.
         '';
       };
 
@@ -55,7 +53,7 @@
             apps.regenerate-lockfile = lib.regenerateLockFileApp lockFileContents;
           }
           // pkgs.lib.optionalAttrs (builtins.readDir path ? "project.ncl") rec {
-            nickelOutputs = lib.importNcl path "project.ncl" inputs;
+            nickelOutputs = lib.importNcl path "project.ncl" inputs lockFileContents;
             packages.default = nickelOutputs.packages.default or {};
             devShells = nickelOutputs.shells or {};
           });
@@ -66,6 +64,7 @@
           inherit system;
           flakeRoot = self.outPath;
           nickel = inputs.nickel.packages."${system}".nickel-lang-cli;
+          organistLib = self.lib.${system};
         };
         pkgs = nixpkgs.legacyPackages.${system};
       in {
@@ -109,9 +108,7 @@
           pkgs.writeShellApplication {
             name = "regenerate-lockfile";
             text = ''
-              cat > nickel.lock.ncl <<EOF
-              ${self.lib.${system}.buildLockFileContents contents}
-              EOF
+              cat > nickel.lock.ncl <${builtins.toFile "nickel.lock.ncl" (self.lib.${system}.buildLockFileContents contents)}
             '';
           };
 

--- a/run-test.sh
+++ b/run-test.sh
@@ -28,7 +28,6 @@ prepare_shell() {
     --override-input organist "path:$PROJECT_ROOT" \
     --override-input nixpkgs "path:$NIXPKGS_PATH" \
     --accept-flake-config
-  nix run .#regenerate-lockfile --accept-flake-config
 }
 
 # Note: running in a subshell (hence the parens and not braces around the function body) so that the trap-based cleanup happens whenever we exit


### PR DESCRIPTION
Re-generate expected contents of nickel.lock.ncl on every importNcl call, check if it matches one in the sources and generate a new source tree with new nickel.lock.ncl if it doesn't. Note that expected lockfile contents depend only on flake parameters. Also note that when lockfile contents don't match the expected value, we'll make a full copy of the source tree during evalutaion of Nickel file.

Fixes #105
Fixes #116
