### PR TITLE
Format all Nickel files

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Run flake checks
       run: |
-        nix flake check
+        nix flake check -L
 
     - name: Check flake.lock
       run: |

--- a/examples/c-hello-world/project.ncl
+++ b/examples/c-hello-world/project.ncl
@@ -17,7 +17,8 @@ let organist = inputs.organist in
           gcc %{organist.lib.import_file "hello.c"} -o hello
           mkdir -p $out/bin
           cp hello $out/bin/hello
-        "% | organist.contracts.NixString,
+        "%
+            | organist.contracts.NixString,
       },
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -153,6 +153,26 @@
           ${pkgs.lib.getExe pkgs.alejandra} --check ${self}
           touch $out
         '';
+
+        checks.nickel-format =
+          pkgs.runCommand "check-nickel-format" {
+            buildInputs = [
+              inputs.nickel.packages.${system}.nickel-lang-cli
+            ];
+          } ''
+            cd ${self}
+            failed=""
+            for f in $(find . -name future -prune -or -name '*.ncl' -print); do
+              if ! diff -u "$f" <(nickel format -f "$f"); then
+                failed="$failed $f"
+              fi
+            done
+            if [ "$failed" != "" ]; then
+              echo "Following files need to be formatted: $failed"
+              exit 1
+            fi
+            touch $out
+          '';
       }
     );
 }

--- a/lib/builders.ncl
+++ b/lib/builders.ncl
@@ -3,7 +3,9 @@ let { NickelDerivation, Derivation, NixString, .. } = import "contracts.ncl" in
 let lib = import "lib.ncl" in
 
 let concat_strings_sep = fun sep values =>
-  if std.array.length values == 0 then "" else
+  if std.array.length values == 0 then
+    ""
+  else
     std.array.reduce_left (fun acc value => nix-s%"%{acc}%{sep}%{value}"%) values
 in
 {
@@ -44,7 +46,8 @@ in
       Makes a derivation that runs all the build phases from nixpkgs' stdenv as the `build_command`.
       Can be controlled with environment variables in the same way as `stdenv.mkDerivation`.
     "%
-    = {
+    =
+      {
         name,
         version,
         build_command = {
@@ -56,7 +59,8 @@ in
           stdenv = lib.import_nix "nixpkgs#stdenv"
         },
         nix_drv = env & structured_env,
-      } | NickelPkg,
+      }
+        | NickelPkg,
 
   Shell
     | doc m%"

--- a/lib/contracts.ncl
+++ b/lib/contracts.ncl
@@ -47,7 +47,7 @@ in
   NullOr
     | doc "Make a contract nullable"
     = fun contract label value =>
-    if value == null then value else std.contract.apply contract label value,
+      if value == null then value else std.contract.apply contract label value,
 
   # TODO: more precise contract
   Derivation
@@ -235,14 +235,14 @@ from the Nix world) or a derivation defined in Nickel.
       The specification of a Nix input in a Nickel expression.
     "%
     = {
-        "%{type_field}" | force = "nixInput",
-        input
-          | doc "The flake input from which we'll resolve this input"
-          | String
-          | default
-          = "nixpkgs",
-        attr_path
-          | doc m%"
+      "%{type_field}" | force = "nixInput",
+      input
+        | doc "The flake input from which we'll resolve this input"
+        | String
+        | default
+        = "nixpkgs",
+      attr_path
+        | doc m%"
             The path to look for in the given flake input.
 
             This follows the same search rules as the `nix build` cli, namely
@@ -250,47 +250,46 @@ from the Nix world) or a derivation defined in Nickel.
             - InputPath
             - "packages".system.InputPath
             - "legacyPackages".system.InputPath
-            "%
-          | InputPath
-          | optional,
-      },
+          "%
+        | InputPath
+        | optional,
+    },
 
-    NixInputSugar
-      | doc m%"
+  NixInputSugar
+    | doc m%"
         Syntactic sugar for defining a `NixInput` to allow writing inputs
         directly as strings of the form `{inputName}#{path}`
       "%
-      =
-      fun label value =>
-        if std.is_string value then
-          let hashPosition = (std.string.find "#" value).index in
-          let value' =
-            if hashPosition == -1 then
-              { input = value, attr_path = [] }
-            else
-              {
-                input = std.string.substring 0 hashPosition value,
-                attr_path =
-                  std.string.split
-                    "."
-                    (
-                      std.string.substring
-                        (hashPosition + 1)
-                        (std.string.length value)
-                        value
-                    ),
-              }
-          in
-          value' |> std.contract.apply NixInput label
-        else
-          std.contract.apply NixInput label value,
+    = fun label value =>
+      if std.is_string value then
+        let hashPosition = (std.string.find "#" value).index in
+        let value' =
+          if hashPosition == -1 then
+            { input = value, attr_path = [] }
+          else
+            {
+              input = std.string.substring 0 hashPosition value,
+              attr_path =
+                std.string.split
+                  "."
+                  (
+                    std.string.substring
+                      (hashPosition + 1)
+                      (std.string.length value)
+                      value
+                  ),
+            }
+        in
+        value' |> std.contract.apply NixInput label
+      else
+        std.contract.apply NixInput label value,
 
   NixPath
     | doc "A path to be imported in the Nix store"
     = {
-    "%{type_field}" | force = "nixPath",
-    path | String,
-  },
+      "%{type_field}" | force = "nixPath",
+      path | String,
+    },
 
   OrganistShells = {
     dev | NickelDerivation = build,
@@ -311,5 +310,4 @@ from the Nix world) or a derivation defined in Nickel.
       | optional,
     ..
   },
-
 }

--- a/lib/shells.ncl
+++ b/lib/shells.ncl
@@ -120,22 +120,21 @@ in
               cmd = nix-s%"%{lib.import_nix "nixpkgs#bash"}/bin/bash"%,
               args = [
                 "-c",
-                # Sorry about Topiary formatting of the following lines
                 nix-s%"
-            source .attrs.sh
-            export PATH='%{lib.import_nix "nixpkgs#coreutils"}/bin'":$PATH"
-            mkdir -p ${outputs[out]}/bin
-            echo "$0" > ${outputs[out]}/bin/stack
-            chmod a+x ${outputs[out]}/bin/*
-          "%,
+                  source .attrs.sh
+                  export PATH='%{lib.import_nix "nixpkgs#coreutils"}/bin'":$PATH"
+                  mkdir -p ${outputs[out]}/bin
+                  echo "$0" > ${outputs[out]}/bin/stack
+                  chmod a+x ${outputs[out]}/bin/*
+                "%,
                 nix-s%"
-            #!%{lib.import_nix "nixpkgs#bash"}/bin/bash
-            %{lib.import_nix "nixpkgs#stack"}/bin/stack \
-              --nix \
-              --no-nix-pure \
-              --nix-path="nixpkgs=%{lib.import_nix "nixpkgs#path"}" \
-              "$@"
-          "%,
+                  #!%{lib.import_nix "nixpkgs#bash"}/bin/bash
+                  %{lib.import_nix "nixpkgs#stack"}/bin/stack \
+                    --nix \
+                    --no-nix-pure \
+                    --nix-path="nixpkgs=%{lib.import_nix "nixpkgs#path"}" \
+                    "$@"
+                "%,
               ],
             },
           }

--- a/notes/builder-draft.ncl
+++ b/notes/builder-draft.ncl
@@ -1,26 +1,32 @@
 # Draft notepad took during Nixel sessions, brainstorming about the interface
 # and the interface of Nickel devshell builders.
 {
-  BinShBuilder = DerivationInterface & {
-    build_script | Str,
-    build_command = [
-      "/bin/sh",
-      ((import "nix_builtins.ncl").write_text "builder" build_script).path,
-    ],
-  },
+  BinShBuilder =
+    DerivationInterface
+    & {
+      build_script | Str,
+      build_command = [
+        "/bin/sh",
+        ((import "nix_builtins.ncl").write_text "builder" build_script).path,
+      ],
+    },
 
-  GenericCargoBuilder = BinShBuilder & {
-    cargo | Derivation,
+  GenericCargoBuilder =
+    BinShBuilder
+    & {
+      cargo | Derivation,
 
-    build_script = "%{cargo}/bin/cargo build",
-  },
+      build_script = "%{cargo}/bin/cargo build",
+    },
 
-  Cargo5Builder = GenericCargoBuilder & {
-    build_inputs = { cargo5 },
-    cargo = build_inputs.cargo5,
-  },
+  Cargo5Builder =
+    GenericCargoBuilder
+    & {
+      build_inputs = { cargo5 },
+      cargo = build_inputs.cargo5,
+    },
 
-  Drv = {out, drv_path}, 
+  Drv = { out, drv_path },
 
   drv_builder = {
     name | Str,
@@ -30,23 +36,29 @@
     derivation | Drv = nix_builtins.derivation name version system build_command,
   },
 
-  PackageDef = BinShBuilder & {
-    inputs | default = {},
-    build_inputs | default = {},
-    install_phase | Str | default = "",
-    build_phase | Str | default = "",
-    build_script | Str = m%"
-      %{build_phase}
-      %{install_phase}
-    "%m,
-    ..
-  },
+  PackageDef =
+    BinShBuilder
+    & {
+      inputs | default = {},
+      build_inputs | default = {},
+      install_phase | Str | default = "",
+      build_phase | Str | default = "",
+      build_script | Str =
+          m%"
+            %{build_phase}
+            %{install_phase}
+          "%
+            m,
+      ..
+    },
 
   DerivationInterface = {
     name | Str,
     version | Str,
-    system | {arch | Str, os | Str} 
-           | default = {arch = "x86_64", os = "linux"},
+    system
+      | { arch | Str, os | Str }
+      | default
+      = { arch = "x86_64", os = "linux" },
     build_command | Array Str,
     ..
   },
@@ -55,14 +67,16 @@
   Derivation = {
     name | Str,
     version | Str,
-    system | {..},
+    system | { .. },
     build_command | Array Str,
-    derivation | {..},
+    derivation | { .. },
   },
 
-  Package = PackageDef & {
-   derivation | Drv,
-  },
+  Package =
+    PackageDef
+    & {
+      derivation | Drv,
+    },
 
   Unit = Dyn,
   Effect = fun contract => Dyn,

--- a/templates/default/project.ncl
+++ b/templates/default/project.ncl
@@ -11,4 +11,5 @@ let organist = inputs.organist in
   shells.dev = {
     packages.hello = organist.lib.import_nix "nixpkgs#hello",
   },
-} | organist.contracts.OrganistExpression
+}
+  | organist.contracts.OrganistExpression


### PR DESCRIPTION
Exclude `future` dir because it has some very old Nickel code that isn't parsed correctly.
Also add a check to make sure `nickel format` doesn't want to change them.
Also changed strings in `lib/shells.ncl` to be prettier because now `nickel format` doesn't complain about them.

Fixes #69
