### PR TITLE
Remove the nickel cachix cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,11 +6,9 @@
 
   nixConfig = {
     extra-substituters = [
-      "https://tweag-nickel.cachix.org"
       "https://organist.cachix.org"
     ];
     extra-trusted-public-keys = [
-      "tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA="
       "organist.cachix.org-1:GB9gOx3rbGl7YEh6DwOscD1+E/Gc5ZCnzqwObNH2Faw="
     ];
   };


### PR DESCRIPTION
We shouldn't need it since the Nickel version we use is already in the
organist cache.

It's not too harmful to have it, but it's a small hindrance for users:

The classic path for a new user is:

```console
$ nix flake init -t github:nickel-lang/organist
$ nix develop
```

The first command will prompt to trust `https://tweag-nickel.cachix.org https://organist.cachix.org` as `extra-substituters` (+ the associated public keys), and the second one to trust `https://organist.cachix.org` as `extra-substituters` (+ the associated public keys again). Which makes a lot of scary messages and things to accept.

By only using `organist` as the binary cache for the repo, we keep everything in sync and make sure that users will only be prompted once (well, twice because of the public keys).
