### PR TITLE
Add upstream Nickel cache to CI

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -15,6 +15,9 @@ runs:
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
         github_access_token: ${{ inputs.SECRET_GITHUB_TOKEN }}
+        extra_nix_config: |
+          substituters = https://tweag-nickel.cachix.org https://cache.nixos.org/
+          trusted-public-keys = tweag-nickel.cachix.org-1:GIthuiK4LRgnW64ALYEoioVUQBWs0jexyoYVeLDBwRA= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
     - name: Configure Cachix
       uses: cachix/cachix-action@v12


### PR DESCRIPTION
While #132 removed it from the flake because flake users should be able to fetch everything from organist cache, CI still would benefit from fetching from upstream cache to avoid unnecessary rebuilds when updating Nickel, and then push these paths to the organist cache.
