### PR TITLE
move buildLockFile and buildLockFileContents to lib.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,18 +64,7 @@
         };
         pkgs = nixpkgs.legacyPackages.${system};
       in {
-        lib.importNcl = lib.importNcl;
-
-        # Flake app to generate nickel.lock.ncl file. Example usage:
-        #   apps = {
-        #     regenerate-lockfile = organist.lib.${system}.regenerateLockFileApp {
-        #       organist = organist.lib.${system}.lockFileContents;
-        #     };
-        #   };
-        lib.regenerateLockFileApp = contents: {
-          type = "app";
-          program = pkgs.lib.getExe (self.lib.${system}.buildLockFile contents);
-        };
+        inherit lib;
 
         apps.run-test = let
           testScript = pkgs.writeShellApplication {

--- a/flake.nix
+++ b/flake.nix
@@ -59,10 +59,8 @@
     // flake-utils.lib.eachDefaultSystem (
       system: let
         lib = pkgs.callPackage ./lib/lib.nix {
-          inherit system;
           flakeRoot = self.outPath;
           nickel = inputs.nickel.packages."${system}".nickel-lang-cli;
-          organistLib = self.lib.${system};
         };
         pkgs = nixpkgs.legacyPackages.${system};
       in {

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -6,7 +6,6 @@
   system,
   lib,
   flakeRoot,
-  organistLib,
 }: let
   # Export a Nix value to be consumed by Nickel
   typeField = "$__organist_type";

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -63,6 +63,16 @@
         cat > nickel.lock.ncl <${builtins.toFile "nickel.lock.ncl" (buildLockFileContents contents)}
       '';
     };
+  # Flake app to generate nickel.lock.ncl file. Example usage:
+  #   apps = {
+  #     regenerate-lockfile = organist.lib.${system}.regenerateLockFileApp {
+  #       organist = organist.lib.${system}.lockFileContents;
+  #     };
+  #   };
+  regenerateLockFileApp = contents: {
+    type = "app";
+    program = lib.getExe (buildLockFile contents);
+  };
 
   # Import a Nickel value produced by the Organist DSL
   importFromNickel = flakeInputs: system: baseDir: value: let
@@ -179,4 +189,11 @@
     {rawNickel = nickelResult;}
     // (importFromNickel flakeInputs system baseDir (builtins.fromJSON
         (builtins.unsafeDiscardStringContext (builtins.readFile nickelResult))));
-in {inherit importNcl buildLockFile;}
+in {
+  inherit
+    importNcl
+    buildLockFile
+    buildLockFileContents
+    regenerateLockFileApp
+    ;
+}


### PR DESCRIPTION
previously `buildLockFile` and
`buildLockFileContents` were only exposed through
the flake, even though `lib/lib.nix` depends
on them. This made using organist without flakes
more complicated, as those two function definitions had to be copied in the consuming nix code.

Now using organist without flakes is as simple as

```nix
let
  pkgs = import <nixpkgs> {};
  organist = builtins.fetchTarball {
    ...
  };
  organistLib = pkgs.callPackage (organist + "/lib/lib.nix") {
    flakeRoot = organist;
    inherit organistLib;
  };
  lockFileContents = {
    organist = "${organist}/lib/nix.ncl";
  };
in {
  organist = organistLib.importNcl
    ./.
    "project.ncl"
    {nixpkgs = pkgs;}
    lockFileContents;
  regenerate-lockfile = organistLib.buildLockFile lockFileContents;
}
```

Should `lockFileContents` also be moved there?
Is there a reason a downstream user would set it
to something else?

This also removes the need to pass organistLib
to itself.