### PR TITLE
Provide a way of using Organist without flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,30 @@ Organist can be used to declare the dependencies for your project.
 These can then be instantiated using [Nix](https://nixos.org/nix).
 
 More information on <./doc/dependency-management.md>.
+
+## Using without flakes
+
+While Organist is focused on usage with flakes, you can use it without them like this:
+
+```nix
+# shell.nix
+let
+  pkgs = import <nixpkgs> {};
+  organistSrc = builtins.fetchTarball "https://github.com/nickel-lang/organist/archive/main.tar.gz";
+  organist = pkgs.callPackage "${organistSrc}/lib/lib.nix" {inherit organistSrc;};
+in
+  (organist.importNcl {baseDir = ./.;}).shells.default
+```
+
+And then use `nix develop -f shell.nix` as usual. Note that this will not use nixpkgs and Nickel from Organist's flake.lock.
+You can use flake-compat to use them:
+
+```nix
+# shell.nix
+let
+  flake-compat = builtins.fetchTarball "https://github.com/edolstra/flake-compat/archive/master.tar.gz";
+  organistSrc = builtins.fetchTarball "https://github.com/nickel-lang/organist/archive/main.tar.gz";
+  organist = ((import flake-compat) {src = organistSrc;}).defaultNix.lib.${builtins.currentSystem};
+in
+  (organist.importNcl {baseDir = ./.;}).shells.default
+```


### PR DESCRIPTION
Some people (see https://github.com/nickel-lang/organist/pull/134 by @BurNiinTRee for example) want to use Organist without flakes.
This PR:
- documents a way for doing that and adds a test for it
- cleans up `lib.nix` arguments so that `pkgs.callPackage` can subsitute all of them
- cleans up `importNcl` interface so that it's easy to use with just a path to a directory
