### PR TITLE
Fix running without nickel.lock.ncl present

### DIFF
--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -160,7 +160,11 @@
         ''
         ''
           cp -r "${sources}" sources
-          chmod +w sources sources/nickel.lock.ncl
+          if [ -f sources/nickel.lock.ncl ]; then
+            chmod +w sources sources/nickel.lock.ncl
+          else
+            chmod +w sources
+          fi
           cat > sources/nickel.lock.ncl <<EOF
           ${expectedLockfileContents}
           EOF

--- a/run-test.sh
+++ b/run-test.sh
@@ -41,8 +41,20 @@ test_one_template () (
   pushd ./example
   sed -i "s/shells\.Bash/shells.$target/" project.ncl
   prepare_shell
-  nickel export --format raw <<<'(import "'"$PROJECT_ROOT"'/lib/shell-tests.ncl").'"$target"'.script' \
-    | nix develop --accept-flake-config --print-build-logs --command bash
+
+  TEST_SCRIPT="$(nickel export --format raw <<<'(import "'"$PROJECT_ROOT"'/lib/shell-tests.ncl").'"$target"'.script')"
+
+  echo "Running with incorrect nickel.lock.ncl" 1>&2
+  nix develop --accept-flake-config --print-build-logs --command bash <<<"$TEST_SCRIPT"
+
+  echo "Running without nickel.lock.ncl" 1>&2
+  rm nickel.lock.ncl
+  nix develop --accept-flake-config --print-build-logs --command bash <<<"$TEST_SCRIPT"
+
+  echo "Run with proper nickel.lock.ncl" 1>&2
+  nix run .\#regenerate-lockfile
+  nix develop --accept-flake-config --print-build-logs --command bash <<<"$TEST_SCRIPT"
+
   popd
   popd
   clean


### PR DESCRIPTION
It was failing with:

```
error: builder for '/nix/store/p87gqv2g1gc59f3rq04b3ygkq8m60di2-nickel-res.json.drv' failed with exit code 1;
       last 1 log lines:
       > chmod: cannot access 'sources/nickel.lock.ncl': No such file or directory
       For full logs, run 'nix-store -l /nix/store/p87gqv2g1gc59f3rq04b3ygkq8m60di2-nickel-res.json.drv'.
```

Also add tests for cases without nickel.lock.ncl and with expected one.

Extracted from https://github.com/nickel-lang/organist/pull/135 for quicker turnaround.
