### PR TITLE
Add shim for `builtins.placeholder` to lib.ncl

### DIFF
--- a/lib/contracts.ncl
+++ b/lib/contracts.ncl
@@ -6,6 +6,10 @@ let predicate | doc "Various predicates used to define contracts"
       std.is_record x
       && std.record.has_field type_field x
       && x."%{type_field}" == "nixPath",
+    is_nix_placeholder = fun x =>
+      std.is_record x
+      && std.record.has_field type_field x
+      && x."%{type_field}" == "nixPlaceholder",
     is_nix_input = fun x =>
       std.is_record x
       && std.record.has_field type_field x
@@ -25,6 +29,7 @@ let predicate | doc "Various predicates used to define contracts"
       is_derivation x
       || std.is_string x
       || is_nix_path x
+      || is_nix_placeholder x
   }
   in
 
@@ -289,6 +294,13 @@ from the Nix world) or a derivation defined in Nickel.
     = {
       "%{type_field}" | force = "nixPath",
       path | String,
+    },
+
+  NixPlaceholder
+    | doc "A path to the given output resolved later in the Nix store"
+    = {
+      "%{type_field}" | force = "nixPlaceholder",
+      output | String,
     },
 
   OrganistShells = {

--- a/lib/lib.ncl
+++ b/lib/lib.ncl
@@ -19,4 +19,6 @@ let contracts = import "contracts.ncl" in
     = fun filepath => { path = filepath },
   import_nix | contracts.NixInputSugar -> contracts.NixInput
     = fun x => x,
+  placeholder | String -> contracts.NixPlaceholder
+    = fun _output => { output = _output }
 }

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -113,6 +113,8 @@
               possibleAttrPaths;
           in
             lib.getAttrFromPath chosenAttrPath flakeInputs
+          else if organistType == "nixPlaceholder"
+          then builtins.placeholder value.output
           else builtins.mapAttrs (_: importFromNickel_) value
       )
     else if (type == "list")


### PR DESCRIPTION
This is in line with `import_nix` or `import_file`.

This will be necessary if there will ever be a "organist-pkgs" independent of `nixpkgs`