### PR TITLE
Dogfood devshells

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
 
     - name: Installing Nix
-      uses: cachix/install-nix-action@v21
+      uses: cachix/install-nix-action@v23
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
         github_access_token: ${{ inputs.SECRET_GITHUB_TOKEN }}

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,44 @@
     nixpkgs,
     flake-utils,
     nickel,
-  } @ inputs:
+  } @ inputs: let
+    # Generate typical flake outputs from .ncl files in path for provided systems (default from flake-utils):
+    #
+    # apps.${system}.regenerate-lockfile generated from optional lockFileContents argument,
+    #   defaulting to `organist` pointing to this flake
+    # devShells.${system} and packages.${system} generated from project.ncl
+    #
+    # (to be extended with more features later)
+    outputsFromNickel = baseDir: flakeInputs: {
+      systems ? flake-utils.lib.defaultSystems,
+      lockFileContents ? {
+        organist = "${self}/lib/nix.ncl";
+      },
+    }:
+      flake-utils.lib.eachSystem systems (system: let
+        lib = self.lib.${system};
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+        {
+          apps.regenerate-lockfile = lib.regenerateLockFileApp lockFileContents;
+        }
+        // pkgs.lib.optionalAttrs (builtins.readDir baseDir ? "project.ncl") rec {
+          nickelOutputs = lib.importNcl {
+            inherit baseDir flakeInputs lockFileContents;
+          };
+          packages =
+            if nickelOutputs ? packages && nickelOutputs.packages ? default
+            then {
+              default = nickelOutputs.packages.default;
+            }
+            else {};
+          devShells = nickelOutputs.shells or {};
+        });
+
+    computedOutputs = outputsFromNickel ./. inputs {
+      lockFileContents.organist = "./lib/nix.ncl";
+    };
+  in
     {
       templates.default = {
         path = ./templates/default;
@@ -29,35 +66,9 @@
           You can run `nix develop` to enter the dev shell.
         '';
       };
-
-      # Generate typical flake outputs from .ncl files in path for provided systems (default from flake-utils):
-      #
-      # apps.${system}.regenerate-lockfile generated from optional lockFileContents argument,
-      #   defaulting to `organist` pointing to this flake
-      # devShells.${system} and packages.${system} generated from project.ncl
-      #
-      # (to be extended with more features later)
-      flake.outputsFromNickel = baseDir: flakeInputs: {
-        systems ? flake-utils.lib.defaultSystems,
-        lockFileContents ? {
-          organist = "${self}/lib/nix.ncl";
-        },
-      }:
-        flake-utils.lib.eachSystem systems (system: let
-          lib = self.lib.${system};
-          pkgs = nixpkgs.legacyPackages.${system};
-        in
-          {
-            apps.regenerate-lockfile = lib.regenerateLockFileApp lockFileContents;
-          }
-          // pkgs.lib.optionalAttrs (builtins.readDir baseDir ? "project.ncl") rec {
-            nickelOutputs = lib.importNcl {
-              inherit baseDir flakeInputs lockFileContents;
-            };
-            packages.default = nickelOutputs.packages.default or {};
-            devShells = nickelOutputs.shells or {};
-          });
+      flake.outputsFromNickel = outputsFromNickel;
     }
+    // computedOutputs
     // flake-utils.lib.eachDefaultSystem (
       system: let
         lib = pkgs.callPackage ./lib/lib.nix {
@@ -68,28 +79,24 @@
       in {
         inherit lib;
 
-        apps.run-test = let
-          testScript = pkgs.writeShellApplication {
-            name = "test-templates";
-            runtimeInputs = [
-              inputs.nickel.packages."${system}".nickel-lang-cli
-              pkgs.parallel
-              pkgs.gnused
-            ];
-            text = builtins.readFile ./run-test.sh;
+        apps =
+          computedOutputs.apps.${system}
+          // {
+            run-test = let
+              testScript = pkgs.writeShellApplication {
+                name = "test-templates";
+                runtimeInputs = [
+                  inputs.nickel.packages."${system}".nickel-lang-cli
+                  pkgs.parallel
+                  pkgs.gnused
+                ];
+                text = builtins.readFile ./run-test.sh;
+              };
+            in {
+              type = "app";
+              program = pkgs.lib.getExe testScript;
+            };
           };
-        in {
-          type = "app";
-          program = pkgs.lib.getExe testScript;
-        };
-
-        devShells.default = pkgs.mkShell {
-          packages = [
-            inputs.nickel.packages."${system}".default
-            pkgs.parallel
-            pkgs.alejandra
-          ];
-        };
 
         checks.alejandra = pkgs.runCommand "check-alejandra" {} ''
           ${pkgs.lib.getExe pkgs.alejandra} --check ${self}

--- a/nickel.lock.ncl
+++ b/nickel.lock.ncl
@@ -1,0 +1,3 @@
+{
+  organist = import "./lib/nix.ncl",
+}

--- a/project.ncl
+++ b/project.ncl
@@ -1,0 +1,16 @@
+let inputs = import "./nickel.lock.ncl" in
+let organist = inputs.organist in
+let import_nix = organist.lib.import_nix in
+
+{
+  shells =
+    organist.shells.Bash
+    & {
+      build.packages = {
+        nickel-lang-cli = import_nix "nickel#nickel-lang-cli",
+        parallel = import_nix "nixpkgs#parallel",
+        gnused = import_nix "nixpkgs#gnused",
+      },
+    },
+}
+  | organist.contracts.OrganistExpression


### PR DESCRIPTION
Add project.ncl and nickel.lock.ncl, use them for this very flake. For now use only devshells.

Update cachix/install-nix-action to install Nix 2.17 that doesn't evaluate `packages` for all systems on `nix flake check`.

Preparation for dogfooding future improvements from https://github.com/nickel-lang/organist/issues/58
