### PR TITLE
Add the nickel LSP to the dev shell

### DIFF
--- a/project.ncl
+++ b/project.ncl
@@ -11,6 +11,9 @@ let import_nix = organist.lib.import_nix in
         parallel = import_nix "nixpkgs#parallel",
         gnused = import_nix "nixpkgs#gnused",
       },
+      dev.packages = {
+        nls = import_nix "nickel#lsp-nls",
+      },
     },
 }
   | organist.contracts.OrganistExpression


### PR DESCRIPTION
The dependency to the lsp was accidentally removed by #139 which changed the dependency from `nickel#default` (a buildenv of both the lsp and the cli) to `nickel#nickel-lang-cli`.

Now that we're using organist, we can actually have the `build` shell depend only on the cli and the dev one add the lsp.
