### PR TITLE
Move checks to project.ncl

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,31 +100,6 @@
               program = pkgs.lib.getExe testScript;
             };
           };
-
-        checks.alejandra = pkgs.runCommand "check-alejandra" {} ''
-          ${pkgs.lib.getExe pkgs.alejandra} --check ${self}
-          touch $out
-        '';
-
-        checks.nickel-format =
-          pkgs.runCommand "check-nickel-format" {
-            buildInputs = [
-              inputs.nickel.packages.${system}.nickel-lang-cli
-            ];
-          } ''
-            cd ${self}
-            failed=""
-            for f in $(find . -name future -prune -or -name '*.ncl' -print); do
-              if ! diff -u "$f" <(nickel format -f "$f"); then
-                failed="$failed $f"
-              fi
-            done
-            if [ "$failed" != "" ]; then
-              echo "Following files need to be formatted: $failed"
-              exit 1
-            fi
-            touch $out
-          '';
       }
     );
 }

--- a/lib/builders.ncl
+++ b/lib/builders.ncl
@@ -1,4 +1,4 @@
-let { NickelDerivation, Derivation, NixString, .. } = import "contracts.ncl" in
+let { NickelDerivation, Derivation, NixString, NixEnvironmentVariable, .. } = import "contracts.ncl" in
 
 let lib = import "lib.ncl" in
 
@@ -55,9 +55,9 @@ in
           args = ["-c", "set -euo pipefail; source .attrs.sh; source $stdenv/setup; genericBuild"],
         },
         structured_env = {},
-        env = {
-          stdenv = lib.import_nix "nixpkgs#stdenv"
-        },
+        env | { _ : NixEnvironmentVariable } = {
+            stdenv | default = lib.import_nix "nixpkgs#stdenv",
+          },
         nix_drv = env & structured_env,
       }
         | NickelPkg,

--- a/lib/contracts.ncl
+++ b/lib/contracts.ncl
@@ -303,6 +303,35 @@ from the Nix world) or a derivation defined in Nickel.
       output | String,
     },
 
+  NixEnvironmentVariable
+    | doc m%"
+        Covers all types that are allowed in Nix derivation's environment variables:
+        - strings
+        - arrays of strings
+        - records with string values
+      "%
+    = fun label value =>
+      let Contract =
+        if std.is_string value then
+          NixString
+        else if std.is_record value then
+          if std.record.has_field type_field value
+          || (
+            std.record.has_field "tag" value
+            && value.tag == 'SymbolicString
+            && std.record.has_field "prefix" value
+            && value.prefix == 'nix
+          ) then
+            NixString
+          else
+            { _ | NixString }
+        else if std.is_array value then
+          Array NixString
+        else
+          std.contract.blame_with_message "Must be string, array of strings or record with string values" label
+      in
+      std.contract.apply Contract label value,
+
   OrganistShells = {
     dev | NickelDerivation = build,
     build | NickelDerivation,

--- a/project.ncl
+++ b/project.ncl
@@ -15,5 +15,45 @@ let import_nix = organist.lib.import_nix in
         nls = import_nix "nickel#lsp-nls",
       },
     },
+
+  flake.checks
+    | {
+      _ | {
+        version
+        = "",
+        env.stdenv
+        = import_nix "nixpkgs#stdenvNoCC",
+        ..
+      }
+    }
+    | { _ | organist.builders.NixpkgsPkg }
+    = {
+      alejandra = {
+        name = "check-alejandra",
+        env.buildCommand = nix-s%"
+          %{import_nix "nixpkgs#alejandra"}/bin/alejandra --check %{import_nix "self"}
+          touch $out
+        "%,
+      },
+
+      nickel-format = {
+        name = "check-nickel-format",
+        env.buildInputs.nickel = import_nix "nickel#nickel-lang-cli",
+        env.buildCommand = nix-s%"
+          cd %{import_nix "self"}
+          failed=""
+          for f in $(find . -name future -prune -or -name '*.ncl' -print); do
+            if ! diff -u "$f" <(nickel format -f "$f"); then
+              failed="$failed $f"
+            fi
+          done
+          if [ "$failed" != "" ]; then
+            echo "Following files need to be formatted: $failed"
+            exit 1
+          fi
+          touch $out
+        "%,
+      },
+    },
 }
   | organist.contracts.OrganistExpression


### PR DESCRIPTION
It's unclear if we need to implement runCommand ourselves, it's quite simple to achieve necesary result with plaing NixpkgsPkg override.

Introduce NixEnvironmentVariable contract to handle all possible things than might end up in `env`.

Part of https://github.com/nickel-lang/organist/issues/58.
