### PR TITLE
Add lib.to_file mirroring builtins.toFile from Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -100,31 +100,6 @@
               program = pkgs.lib.getExe testScript;
             };
           };
-
-        checks.alejandra = pkgs.runCommand "check-alejandra" {} ''
-          ${pkgs.lib.getExe pkgs.alejandra} --check ${self}
-          touch $out
-        '';
-
-        checks.nickel-format =
-          pkgs.runCommand "check-nickel-format" {
-            buildInputs = [
-              inputs.nickel.packages.${system}.nickel-lang-cli
-            ];
-          } ''
-            cd ${self}
-            failed=""
-            for f in $(find . -name future -prune -or -name '*.ncl' -print); do
-              if ! diff -u "$f" <(nickel format -f "$f"); then
-                failed="$failed $f"
-              fi
-            done
-            if [ "$failed" != "" ]; then
-              echo "Following files need to be formatted: $failed"
-              exit 1
-            fi
-            touch $out
-          '';
       }
     );
 }

--- a/lib/builders.ncl
+++ b/lib/builders.ncl
@@ -1,4 +1,4 @@
-let { NickelDerivation, Derivation, NixString, .. } = import "contracts.ncl" in
+let { NickelDerivation, Derivation, NixString, NixEnvironmentVariable, .. } = import "contracts.ncl" in
 
 let lib = import "lib.ncl" in
 
@@ -55,9 +55,9 @@ in
           args = ["-c", "set -euo pipefail; source .attrs.sh; source $stdenv/setup; genericBuild"],
         },
         structured_env = {},
-        env = {
-          stdenv = lib.import_nix "nixpkgs#stdenv"
-        },
+        env | { _ : NixEnvironmentVariable } = {
+            stdenv | default = lib.import_nix "nixpkgs#stdenv",
+          },
         nix_drv = env & structured_env,
       }
         | NickelPkg,

--- a/lib/contracts.ncl
+++ b/lib/contracts.ncl
@@ -10,6 +10,10 @@ let predicate | doc "Various predicates used to define contracts"
       std.is_record x
       && std.record.has_field type_field x
       && x."%{type_field}" == "nixPlaceholder",
+    is_nix_to_file = fun x =>
+      std.is_record x
+      && std.record.has_field type_field x
+      && x."%{type_field}" == "nixToFile",
     is_nix_input = fun x =>
       std.is_record x
       && std.record.has_field type_field x
@@ -30,6 +34,7 @@ let predicate | doc "Various predicates used to define contracts"
       || std.is_string x
       || is_nix_path x
       || is_nix_placeholder x
+      || is_nix_to_file x
   }
   in
 
@@ -331,6 +336,14 @@ from the Nix world) or a derivation defined in Nickel.
           std.contract.blame_with_message "Must be string, array of strings or record with string values" label
       in
       std.contract.apply Contract label value,
+
+  NixToFile
+    | doc "A path to the given output resolved later in the Nix store"
+    = {
+      "%{type_field}" | force = "nixToFile",
+      name | String,
+      text | NixString,
+    },
 
   OrganistShells = {
     dev | NickelDerivation = build,

--- a/lib/contracts.ncl
+++ b/lib/contracts.ncl
@@ -303,6 +303,35 @@ from the Nix world) or a derivation defined in Nickel.
       output | String,
     },
 
+  NixEnvironmentVariable
+    | doc m%"
+        Covers all types that are allowed in Nix derivation's environment variables:
+        - strings
+        - arrays of strings
+        - records with string values
+      "%
+    = fun label value =>
+      let Contract =
+        if std.is_string value then
+          NixString
+        else if std.is_record value then
+          if std.record.has_field type_field value
+          || (
+            std.record.has_field "tag" value
+            && value.tag == 'SymbolicString
+            && std.record.has_field "prefix" value
+            && value.prefix == 'nix
+          ) then
+            NixString
+          else
+            { _ | NixString }
+        else if std.is_array value then
+          Array NixString
+        else
+          std.contract.blame_with_message "Must be string, array of strings or record with string values" label
+      in
+      std.contract.apply Contract label value,
+
   OrganistShells = {
     dev | NickelDerivation = build,
     build | NickelDerivation,

--- a/lib/lib.ncl
+++ b/lib/lib.ncl
@@ -20,5 +20,7 @@ let contracts = import "contracts.ncl" in
   import_nix | contracts.NixInputSugar -> contracts.NixInput
     = fun x => x,
   placeholder | String -> contracts.NixPlaceholder
-    = fun _output => { output = _output }
+    = fun _output => { output = _output },
+  to_file | String -> contracts.NixString -> contracts.NixToFile
+    = fun _name _text => { name = _name, text = _text },
 }

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -116,6 +116,8 @@
             lib.getAttrFromPath chosenAttrPath flakeInputs
           else if organistType == "nixPlaceholder"
           then builtins.placeholder value.output
+          else if organistType == "nixToFile"
+          then builtins.toFile value.name (importFromNickel_ value.text)
           else builtins.mapAttrs (_: importFromNickel_) value
       )
     else if (type == "list")

--- a/project.ncl
+++ b/project.ncl
@@ -15,5 +15,45 @@ let import_nix = organist.lib.import_nix in
         nls = import_nix "nickel#lsp-nls",
       },
     },
+
+  flake.checks
+    | {
+      _ | {
+        version
+        = "",
+        env.stdenv
+        = import_nix "nixpkgs#stdenvNoCC",
+        ..
+      }
+    }
+    | { _ | organist.builders.NixpkgsPkg }
+    = {
+      alejandra = {
+        name = "check-alejandra",
+        env.buildCommand = nix-s%"
+          %{import_nix "nixpkgs#alejandra"}/bin/alejandra --check %{import_nix "self"}
+          touch $out
+        "%,
+      },
+
+      nickel-format = {
+        name = "check-nickel-format",
+        env.buildInputs.nickel = import_nix "nickel#nickel-lang-cli",
+        env.buildCommand = nix-s%"
+          cd %{import_nix "self"}
+          failed=""
+          for f in $(find . -name future -prune -or -name '*.ncl' -print); do
+            if ! diff -u "$f" <(nickel format -f "$f"); then
+              failed="$failed $f"
+            fi
+          done
+          if [ "$failed" != "" ]; then
+            echo "Following files need to be formatted: $failed"
+            exit 1
+          fi
+          touch $out
+        "%,
+      },
+    },
 }
   | organist.contracts.OrganistExpression

--- a/project.ncl
+++ b/project.ncl
@@ -55,5 +55,7 @@ let import_nix = organist.lib.import_nix in
         "%,
       },
     },
+
+  flake.checks = import "tests/main.ncl",
 }
   | organist.contracts.OrganistExpression

--- a/tests/main.ncl
+++ b/tests/main.ncl
@@ -1,0 +1,3 @@
+{
+  to_file = import "to_file.ncl",
+}

--- a/tests/to_file.ncl
+++ b/tests/to_file.ncl
@@ -1,0 +1,12 @@
+let organist = import "../lib/nix.ncl" in
+let file1 = organist.lib.to_file "file1" "important data" in
+let file2 = organist.lib.to_file "file2" nix-s%"see %{file1}"% in
+organist.builders.NixpkgsPkg
+& {
+  name = "test-to_path",
+  env.buildCommand = nix-s%"
+    [[ $(cat %{file1}) == "important data" ]]
+    [[ $(cat %{file2}) == "see /nix/store/ypiiqm7ig0fzqfz3v4j05g54ffk8svg9-file1" ]]
+    echo OK > $out
+  "%,
+}


### PR DESCRIPTION
Add `lib.to_file` mirroring `builtins.toFile` from Nix

Also add scaffolding for adding library tests to checks.

Part of https://github.com/nickel-lang/organist/issues/58.
