### PR TITLE
Add `nls` to the shells by default

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,14 @@
+(
+  import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;}
+)
+.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,7 @@
     },
     "crane": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nickel",
@@ -42,7 +42,7 @@
     },
     "crane_2": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_4",
         "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "nickel",
@@ -66,13 +66,12 @@
       }
     },
     "flake-compat": {
-      "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -98,6 +97,22 @@
       }
     },
     "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1673956053,
@@ -345,7 +360,7 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "flake-utils": [
           "nickel",
           "flake-utils"
@@ -373,6 +388,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nickel": "nickel",
         "nixpkgs": "nixpkgs_3"

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
   inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nickel.url = "github:tweag/nickel";
+  inputs.flake-compat.url = "github:edolstra/flake-compat";
 
   nixConfig = {
     extra-substituters = [
@@ -18,6 +19,7 @@
     nixpkgs,
     flake-utils,
     nickel,
+    flake-compat,
   } @ inputs: let
     # Generate typical flake outputs from .ncl files in path for provided systems (default from flake-utils):
     #

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
           devShells = nickelOutputs.shells or {} // nickelOutputs.flake.devShells or {};
         });
 
-    computedOutputs = outputsFromNickel ./. inputs {
+    computedOutputs = outputsFromNickel ./. (inputs // {organist = self;}) {
       lockFileContents.organist = "./lib/organist.ncl";
     };
   in

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -195,6 +195,7 @@
     nickelFile ? "project.ncl",
     flakeInputs ? {
       nixpkgs = pkgs;
+      organist = import organistSrc;
     },
     lockFileContents ? {
       organist = "${organistSrc}/lib/organist.ncl";

--- a/lib/nix-interop/shells.ncl
+++ b/lib/nix-interop/shells.ncl
@@ -18,7 +18,7 @@ in
           bash = lib.import_nix "nixpkgs#bash",
         },
       },
-    dev = build,
+    dev.packages.nickel = lib.import_nix "organist#nickel",
   },
 
   Rust =

--- a/project.ncl
+++ b/project.ncl
@@ -11,9 +11,6 @@ let import_nix = organist.nix.import_nix in
         parallel = import_nix "nixpkgs#parallel",
         gnused = import_nix "nixpkgs#gnused",
       },
-      dev.packages = {
-        nls = import_nix "nickel#lsp-nls",
-      },
     },
 
   flake.apps.run-test =
@@ -31,6 +28,11 @@ let import_nix = organist.nix.import_nix in
       type = "app",
       program | organist.nix.derivation.NixString = nix-s%"%{testScript}/bin/run-test.sh"%
     },
+
+  packages = {
+    # Re-exported to make it easy for downstream to depend on them
+    nickel = import_nix "nickel#default",
+  },
 
   flake.checks
     | {


### PR DESCRIPTION
 Having the lsp work out of the box is definitely worth the small cost of the extra dependency (given that we already depend on Nickel for the evaluation, `nls` isn't much)
