### PR TITLE
Document all the exported fields

### DIFF
--- a/lib/nix-interop/builders.ncl
+++ b/lib/nix-interop/builders.ncl
@@ -1,4 +1,4 @@
-let { NickelDerivation, Derivation, NixString, NixEnvironmentVariable, .. } = import "derivation.ncl" in
+let { NickelDerivation, Derivation, NixString, NixEnvironmentVariable, NullOr, .. } = import "derivation.ncl" in
 
 let lib = import "builtins.ncl" in
 
@@ -119,13 +119,18 @@ in
           "%,
         content.text
           | doc "A string representing the body of the script"
-          | NixString
-          | optional,
+          | NullOr NixString
+          | default
+          = null,
         content.file
           | doc "File from which to read the body of the script"
-          | NixString
+          | NullOr NixString
           | default
-          = lib.to_file name content.text,
+          =
+            if content.text == null then
+              null
+            else
+              lib.to_file name content.text,
         runtime_inputs
           | doc m%"
             Packages which will be added to the `PATH` of the script when

--- a/lib/nix-interop/builders.ncl
+++ b/lib/nix-interop/builders.ncl
@@ -64,7 +64,10 @@ in
           args = ["-c", "set -euo pipefail; source .attrs.sh; source $stdenv/setup; genericBuild"],
         },
         structured_env = {},
-        env | { _ : NixEnvironmentVariable } = {
+        env
+          | doc "Environment variables that will be set in the derivation"
+          | { _ : NixEnvironmentVariable }
+          = {
             stdenv | default = lib.import_nix "nixpkgs#stdenv",
           },
         nix_drv = env & structured_env,
@@ -92,7 +95,7 @@ in
         env.shellHook = concat_strings_sep "\n" (std.record.values hooks),
         structured_env.buildInputs = packages,
       }
-        | (NickelPkg & { packages | { _ : Derivation } }),
+        | NickelPkg,
 
   ShellApplication
     | doc m%"
@@ -109,10 +112,44 @@ in
       & {
         name,
         version | default = "0.0.0",
-        content.text | NixString | optional,
-        content.file | NixString | default = lib.to_file name content.text,
-        runtime_inputs | { _ : Derivation } = {},
-        shell_binary | NixString | default = lib.import_nix "nixpkgs#runtimeShell",
+        content
+          | doc m%"
+            The body of the script. Can be either passed directly as a string,
+            or read from a file
+          "%,
+        content.text
+          | doc "A string representing the body of the script"
+          | NixString
+          | optional,
+        content.file
+          | doc "File from which to read the body of the script"
+          | NixString
+          | default
+          = lib.to_file name content.text,
+        runtime_inputs
+          | doc m%"
+            Packages which will be added to the `PATH` of the script when
+            it runs.
+
+            # Example
+
+            ```nickel
+            {
+              jq = import_nix "nixpkgs#jq",
+              nickel = import_nix "nixpkgs#awk",
+            }
+            ```
+          "%
+          | { _ : Derivation }
+          = {},
+        shell_binary
+          | doc m%"
+            The binary that will be run to execute the script.
+            Needs to be bash-compatible.
+          "%
+          | NixString
+          | default
+          = lib.import_nix "nixpkgs#runtimeShell",
 
         env.buildInputs.coreutils = lib.import_nix "nixpkgs#coreutils",
         env.buildCommand = nix-s%"

--- a/lib/nix-interop/builtins.ncl
+++ b/lib/nix-interop/builtins.ncl
@@ -17,10 +17,40 @@ let contracts = import "contracts.ncl" in
           ```
         "%%
     = fun filepath => { path = filepath },
-  import_nix | contracts.NixInputSugar -> contracts.NixInput
+  import_nix
+    | doc m%%"
+      Import a Nix value from one of the flake inputs.
+      The value should be passed in a flakeref-like format
+      `input_name#attribute_path`.
+
+      # Example
+
+      ```nickel
+      cmd = nix-s%"%{import_nix "nixpkgs#hello"}/bin/hello > $out"%
+      ```
+    "%%
+    | contracts.NixInputSugar -> contracts.NixInput
     = fun x => x,
-  placeholder | String -> contracts.NixPlaceholder
+  placeholder
+    | doc m%"
+      Return a placeholder string for the specified output that will be
+      substituted by the corresponding output path at build time.
+
+      Wrapper around the Nix
+      [placeholder](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-placeholder)
+      builtin.
+    "%
+    | String -> contracts.NixPlaceholder
     = fun _output => { output = _output },
-  to_file | String -> contracts.NixString -> contracts.NixToFile
+  to_file
+    | doc m%"
+      Store the string s in a file in the Nix store and return its path.
+      The file has suffix name.
+
+      Wrapper around the Nix
+      [toFile](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-toFile)
+      builtin.
+    "%
+    | String -> contracts.NixString -> contracts.NixToFile
     = fun _name _text => { name = _name, text = _text },
 }

--- a/lib/nix-interop/derivation.ncl
+++ b/lib/nix-interop/derivation.ncl
@@ -62,8 +62,8 @@ in
   # TODO: more precise contract
   Derivation
     | doc m%"
-        Contract representing either a Nix derivation (evaluated and imported
-from the Nix world) or a derivation defined in Nickel.
+      Contract representing either a Nix derivation (evaluated and imported
+      from the Nix world) or a derivation defined in Nickel.
       "%
     = Dyn,
 

--- a/lib/nix-interop/nix.ncl
+++ b/lib/nix-interop/nix.ncl
@@ -1,9 +1,30 @@
 {
-  derivation = import "derivation.ncl",
-  builders = import "builders.ncl",
-  shells = import "shells.ncl",
-  builtins = import "builtins.ncl",
-  utils = import "utils.ncl",
+  derivation
+    | doc m%"
+      Low-level interface for interfacing with Nix values and constructing
+      derivations from Nickel.
+    "%
+    = import "derivation.ncl",
+  builders
+    | doc m%"
+      Library of standard builders used for writing derivations.
+    "%
+    = import "builders.ncl",
+  shells
+    | doc m%"
+      Library of standard development environments.
+    "%
+    = import "shells.ncl",
+  builtins
+    | doc m%"
+      Wrapper around Nix primops and built-in language features.
+    "%
+    = import "builtins.ncl",
+  utils
+    | doc m%"
+      Miscellaneous helper functions.
+    "%
+    = import "utils.ncl",
 
   import_nix = builtins.import_nix,
 }

--- a/lib/nix-interop/shells.ncl
+++ b/lib/nix-interop/shells.ncl
@@ -110,7 +110,14 @@ in
   HaskellStack =
     Bash
     & {
-      build.ghcVersion | default = "927", # User-defined. To keep in sync with the one used by stack
+      build.ghcVersion
+        | doc m%"
+            The GHC version used in the build.
+            Must be kept in sync with the one expected by Stack.
+          "%
+        | String
+        | default
+        = "927",
       build.packages =
         let stack-wrapped =
           {
@@ -146,7 +153,7 @@ in
           nix = lib.import_nix "nixpkgs#nix",
           git = lib.import_nix "nixpkgs#git",
         },
-      dev.ghcVersion,
+      dev.ghcVersion | force = build.ghcVersion,
       dev.packages = {
         ormolu = lib.import_nix "nixpkgs#ormolu",
         haskell-language-server = lib.import_nix "nixpkgs#haskell.packages.ghc%{dev.ghcVersion}.haskell-language-server",


### PR DESCRIPTION
Provide our users some documentation so that they know what the fields refer to.

It's not utterly visible yet unfortunately, but #161 should make that much more visible by making all these fields visible to the LSP:

![image](https://github.com/nickel-lang/organist/assets/7226587/8cc5955c-d6f3-4822-a779-d3e9eb08b9a6)