### PR TITLE
Add editorconfig support

### DIFF
--- a/examples/c-hello-world/project.ncl
+++ b/examples/c-hello-world/project.ncl
@@ -20,5 +20,8 @@ let organist = inputs.organist in
         "%
             | organist.nix.derivation.NixString,
       },
-    }
-}
+    },
+
+  shells = organist.shells.Bash,
+  shells.build.packages.hello = packages.hello,
+} | organist.OrganistExpression

--- a/examples/c-hello-world/test.sh
+++ b/examples/c-hello-world/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+hello

--- a/examples/filegen/flake.nix
+++ b/examples/filegen/flake.nix
@@ -1,0 +1,12 @@
+{
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.organist.url = "github:nickel-lang/organist";
+
+  nixConfig = {
+    extra-substituters = ["https://organist.cachix.org"];
+    extra-trusted-public-keys = ["organist.cachix.org-1:GB9gOx3rbGl7YEh6DwOscD1+E/Gc5ZCnzqwObNH2Faw="];
+  };
+
+  outputs = {organist, ...} @ inputs:
+    organist.flake.outputsFromNickel ./. inputs {};
+}

--- a/examples/filegen/nickel.lock.ncl
+++ b/examples/filegen/nickel.lock.ncl
@@ -1,0 +1,3 @@
+{
+  organist = import "../../lib/organist.ncl",
+}

--- a/examples/filegen/project.ncl
+++ b/examples/filegen/project.ncl
@@ -1,0 +1,27 @@
+let inputs = import "./nickel.lock.ncl" in
+let organist = inputs.organist in
+
+{
+  shells = organist.shells.Bash,
+
+  shells.build = {
+    packages = {},
+  },
+
+  shells.dev = {
+    packages.hello = organist.import_nix "nixpkgs#hello",
+  },
+
+  editorconfig.sections = {
+    "*".indent_style = 'space,
+    "*".indent_size = 2,
+    "*".insert_final_newline = true,
+    "Makefile".indent_style = 'tab,
+    "*.py" = {
+      indent_style = 'space,
+      indent_size = 4,
+    },
+  },
+}
+& organist.tools.editorconfig.Schema
+  | organist.OrganistExpression

--- a/examples/filegen/test.sh
+++ b/examples/filegen/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+cat <<EOF > .editorconfig.expected
+root = true
+
+[*]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+indent_style = space
+
+[Makefile]
+indent_style = tab
+EOF
+
+diff .editorconfig.expected .editorconfig

--- a/lib/editorconfig.ncl
+++ b/lib/editorconfig.ncl
@@ -1,0 +1,91 @@
+let IndentSize = fun label value =>
+  if value == 'tab then
+    value
+  else
+    std.contract.apply Number label value
+in
+let ConfigEntry = {
+  indent_style | optional | [| 'tab, 'space |],
+  indent_size | optional | IndentSize,
+  tab_width | optional | Number,
+  insert_final_newline | optional | Bool,
+  end_of_line | optional | [| 'lf, 'cr, 'crlf |],
+  trim_trailing_whitespace | optional | Bool,
+  insert_final_newline | optional | Bool,
+}
+in
+let Config = { _ : ConfigEntry } in
+let showConfigEntry | String -> ConfigEntry -> String = fun section_name entry =>
+    let content =
+      entry
+      |> std.record.map (fun key value => "%{key} = %{std.to_string value}")
+      |> std.record.values
+      |> std.string.join "\n"
+    in
+    m%"
+  [%{section_name}]
+  %{content}
+  "%
+  in
+let generate
+  | Bool -> {
+    _ : ConfigEntry
+  } -> String
+  = fun is_root cfg =>
+    m%"
+    root = %{std.to_string is_root}
+
+    %{std.record.map showConfigEntry cfg |> std.record.values |> std.string.join "\n\n"}
+
+    "%
+  in
+let EditorConfigSchema = {
+  is_root
+    | doc "Whether to stop searching for other editorconfig files above"
+    | Bool
+    | default
+    = true,
+  sections
+    | doc m%"
+        Sections of the editor configuration.
+        Keys are patterns defining the files that will be considered, and values are some specific settings for these files.
+
+        ## Example
+
+        ```nickel
+        {
+          "*" = {
+            indent_style = 'space,
+            indent_size = 2,
+          },
+
+          "Makefile".indent_size = 'tab,
+        }
+        ```
+      "%
+    | Config
+    | default
+    = {},
+}
+in
+{
+  Schema = {
+    editorconfig
+      | doc m%"
+        Editor configuration (from https://editorconfig.org/)
+      "%
+      | EditorConfigSchema
+      | default
+      = {},
+    files =
+      if editorconfig.sections != {} then
+        {
+          ".editorconfig" = {
+            content = generate editorconfig.is_root editorconfig.sections,
+          }
+        }
+      else
+        {},
+    ..
+  },
+}

--- a/lib/organist.ncl
+++ b/lib/organist.ncl
@@ -4,6 +4,8 @@
   schema = import "./schema.ncl",
   OrganistExpression = schema.OrganistExpression,
   import_nix = nix.builtins.import_nix,
+
+  tools.editorconfig = import "./editorconfig.ncl",
 }
 #TODO: currently, Nickel forbids doc at the toplevel. It's most definitely
 # temporary, as the implementation of RFC005 is ongoing. Once the capability is

--- a/run-test.sh
+++ b/run-test.sh
@@ -107,7 +107,8 @@ test_example () (
   cp -r "$examplePath" ./example
   pushd ./example
   prepare_shell
-  nix build --print-build-logs
+  nix run .\#regenerate-files --print-build-logs
+  nix develop --print-build-logs --command bash test.sh
   popd
   popd
 )


### PR DESCRIPTION
Add a new `editorconfig` schema that exposes and `editorconfig` option to define an [EditorConfig](https://editorconfig.org/) file to be generated.
