### PR TITLE
add procfile support

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -39,4 +39,4 @@ jobs:
     - name: Test devshells
       run: |
         nix run .#run-test template
-        nix run .#run-test example examples/c-hello-world
+        find examples -maxdepth 1 -mindepth 1 -type d -print0 -exec nix run .#run-test example {} \;

--- a/examples/procfile/flake.nix
+++ b/examples/procfile/flake.nix
@@ -1,0 +1,12 @@
+{
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.organist.url = "github:nickel-lang/organist";
+
+  nixConfig = {
+    extra-substituters = ["https://organist.cachix.org"];
+    extra-trusted-public-keys = ["organist.cachix.org-1:GB9gOx3rbGl7YEh6DwOscD1+E/Gc5ZCnzqwObNH2Faw="];
+  };
+
+  outputs = {organist, ...} @ inputs:
+    organist.flake.outputsFromNickel ./. inputs {};
+}

--- a/examples/procfile/nickel.lock.ncl
+++ b/examples/procfile/nickel.lock.ncl
@@ -1,0 +1,3 @@
+{
+  organist = import "../../lib/organist.ncl",
+}

--- a/examples/procfile/project.ncl
+++ b/examples/procfile/project.ncl
@@ -1,0 +1,44 @@
+let inputs = import "./nickel.lock.ncl" in
+let organist = inputs.organist in
+
+let postgres_listen_port = 64441 in
+let redis_listen_port = 64442 in
+
+{
+  shells = organist.shells.Bash,
+
+  shells.build = {
+    packages = {},
+  },
+
+  shells.dev = {
+    packages = {
+      postgresql = organist.import_nix "nixpkgs#postgresql",
+      redis = organist.import_nix "nixpkgs#redis",
+      honcho = organist.import_nix "nixpkgs#honcho",
+    },
+    env.POSTGRES_PORT = "%{std.to_string postgres_listen_port}",
+    env.REDIS_URI = "redis://localhost:%{std.to_string redis_listen_port}",
+  },
+
+  procfile = {
+    postgres =
+      let start_script =
+        {
+          name = "start-postgres",
+          runtime_inputs.postgres = organist.import_nix "nixpkgs#postgresql",
+          content.text = nix-s%"
+          mkdir -p ./.postgres-data
+          initdb ./.postgres-data
+          postgres -D ./.postgres-data -k "$PWD/.postgres-data" -p %{std.to_string postgres_listen_port}
+
+        "%
+        } | organist.nix.builders.ShellApplication
+      in
+      nix-s%"%{start_script}/bin/start-postgres"%,
+    redis = nix-s%"%{organist.import_nix "nixpkgs#redis"}/bin/redis-server --port %{std.to_string redis_listen_port}"%,
+  },
+}
+& organist.tools.editorconfig.Schema
+& organist.tools.procfile.Schema
+  | organist.OrganistExpression

--- a/examples/procfile/test.sh
+++ b/examples/procfile/test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+cat Procfile
+
+honcho -f Procfile check
+honcho -f Procfile start&
+HONCHO_PID=$!
+trap "kill $HONCHO_PID; wait" EXIT
+
+sleep 2
+pg_isready -h localhost -p "$POSTGRES_PORT" -t 10
+redis-cli -u "$REDIS_URI" ping

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -117,7 +117,7 @@
           else if organistType == "nixPlaceholder"
           then builtins.placeholder value.output
           else if organistType == "nixToFile"
-          then builtins.toFile value.name (importFromNickel_ value.text)
+          then writeText value.name (importFromNickel_ value.text)
           else builtins.mapAttrs (_: importFromNickel_) value
       )
     else if (type == "list")

--- a/lib/nix-interop/builders.ncl
+++ b/lib/nix-interop/builders.ncl
@@ -61,7 +61,7 @@ in
         version,
         build_command = {
           cmd = nix-s%"%{lib.import_nix "nixpkgs#bash"}/bin/bash"%,
-          args = ["-c", "set -euo pipefail; source .attrs.sh; source $stdenv/setup; genericBuild"],
+          args = ["-c", "set -euo pipefail; source \"${NIX_ATTRS_SH_FILE:-.attrs.sh}\"; source $stdenv/setup; genericBuild"],
         },
         structured_env = {},
         env
@@ -70,7 +70,9 @@ in
           = {
             stdenv | default = lib.import_nix "nixpkgs#stdenv",
           },
-        nix_drv = env & structured_env,
+        nix_drv =
+          let env' = env in
+          env' & structured_env & { env = env' },
       }
         | NickelPkg,
 

--- a/lib/organist.ncl
+++ b/lib/organist.ncl
@@ -6,6 +6,7 @@
   import_nix = nix.builtins.import_nix,
 
   tools.editorconfig = import "./editorconfig.ncl",
+  tools.procfile = import "./procfile.ncl",
 }
 #TODO: currently, Nickel forbids doc at the toplevel. It's most definitely
 # temporary, as the implementation of RFC005 is ongoing. Once the capability is

--- a/lib/procfile.ncl
+++ b/lib/procfile.ncl
@@ -1,0 +1,37 @@
+let nix = import "./nix-interop/nix.ncl" in
+let ProcfileCommand = nix.derivation.NixString
+in
+let ProcfileSchema = { _ : ProcfileCommand }
+in
+let generate_procfile | ProcfileSchema -> nix.derivation.NixString = fun schema =>
+    schema
+    |> std.record.to_array
+    |> std.array.fold_left
+      (
+        fun acc { field, value } =>
+          nix-s%"
+            %{acc}
+            %{field}: %{value}
+          "%
+      )
+      ""
+  in
+{
+  Schema = {
+    procfile
+      | doc m%"
+        Contents of the [Procfile](https://devcenter.heroku.com/articles/procfile) for deploying on some platforms or local testing.
+      "%
+      | ProcfileSchema
+      | default
+      = {},
+    files =
+      if procfile != {} then
+        {
+          "Procfile".content = generate_procfile procfile
+        }
+      else
+        {},
+    ..
+  }
+}

--- a/tests/to_file.ncl
+++ b/tests/to_file.ncl
@@ -7,7 +7,7 @@ organist.nix.builders.NixpkgsPkg
   version = "0.1",
   env.buildCommand = nix-s%"
     [[ $(cat %{file1}) == "important data" ]]
-    [[ $(cat %{file2}) == "see /nix/store/ypiiqm7ig0fzqfz3v4j05g54ffk8svg9-file1" ]]
+    [[ $(cat %{file2}) == "see /nix/store/wr3qac28s69nkm4x8gg9rrs8518kiwa0-file1" ]]
     echo OK > $out
   "%,
 }


### PR DESCRIPTION
Add a new `tools.procfile` module to generate a [Procfile](https://devcenter.heroku.com/articles/procfile) for running development services (or deployment).

Also fix a couple of related bugs I found while testing it
