### PR TITLE
Only run the full template test for Bash

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -39,4 +39,5 @@ jobs:
     - name: Test devshells
       run: |
         nix run .#run-test template
+        nix run .#run-test template -- --full Bash
         find examples -maxdepth 1 -mindepth 1 -type d -print0 -exec nix run .#run-test example {} \;


### PR DESCRIPTION
It's useless to instantiate the environment six times for each template, so only do that for bash (and instanciate it only once for the rest)