### PR TITLE
Add a basic `direnv` support

### DIFF
--- a/examples/direnv/flake.nix
+++ b/examples/direnv/flake.nix
@@ -1,0 +1,12 @@
+{
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.organist.url = "github:nickel-lang/organist";
+
+  nixConfig = {
+    extra-substituters = ["https://organist.cachix.org"];
+    extra-trusted-public-keys = ["organist.cachix.org-1:GB9gOx3rbGl7YEh6DwOscD1+E/Gc5ZCnzqwObNH2Faw="];
+  };
+
+  outputs = {organist, ...} @ inputs:
+    organist.flake.outputsFromNickel ./. inputs {};
+}

--- a/examples/direnv/nickel.lock.ncl
+++ b/examples/direnv/nickel.lock.ncl
@@ -1,0 +1,3 @@
+{
+  organist = import "../../lib/organist.ncl",
+}

--- a/examples/direnv/project.ncl
+++ b/examples/direnv/project.ncl
@@ -1,0 +1,18 @@
+let inputs = import "./nickel.lock.ncl" in
+let organist = inputs.organist in
+
+{
+  shells = organist.shells.Bash,
+
+  shells.build = {
+    packages = {},
+  },
+
+  shells.dev = {
+    packages.direnv = organist.import_nix "nixpkgs#direnv"
+  },
+}
+  | (
+    organist.OrganistExpression
+    & organist.tools.direnv.Schema
+  )

--- a/examples/direnv/test.sh
+++ b/examples/direnv/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "export FOO=from-direnv" >> .envrc.private
+
+direnv allow
+[[ $(direnv exec . sh -c 'echo $DIRENV_FILE') == "$PWD/.envrc" ]]
+[[ $(direnv exec . sh -c 'echo $FOO') == "from-direnv" ]]

--- a/lib/direnv.ncl
+++ b/lib/direnv.ncl
@@ -1,0 +1,27 @@
+{
+  Schema = {
+    direnv = {
+      enable
+        | doc m%"
+          Whether to enable the [direnv](https://github.com/direnv/direnv) integration.
+        "%
+        | Bool
+        | default
+        = true,
+    },
+    files =
+      if direnv.enable then
+        {
+          ".envrc".content = m%"
+            if ! has nix_direnv_version || ! nix_direnv_version 2.4.0; then
+              source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.4.0/direnvrc" "sha256-XQzUAvL6pysIJnRJyR7uVpmUSZfc7LSgWQwq/4mBr1U="
+            fi
+            nix_direnv_watch_file project.ncl nickel.lock.ncl
+            source_env_if_exists ".envrc.private"
+            use flake
+          "%,
+        }
+      else
+        {},
+  },
+}

--- a/lib/organist.ncl
+++ b/lib/organist.ncl
@@ -7,6 +7,7 @@
 
   tools.editorconfig = import "./editorconfig.ncl",
   tools.procfile = import "./procfile.ncl",
+  tools.direnv = import "./direnv.ncl",
 }
 #TODO: currently, Nickel forbids doc at the toplevel. It's most definitely
 # temporary, as the implementation of RFC005 is ongoing. Once the capability is


### PR DESCRIPTION
Just creates a hardcoded `.envrc` that should work with most Organist projects.
