### PR TITLE
Add the `packages` of the shells to `nativeBuildInputs`

### DIFF
--- a/examples/c-hello-world/hello.c
+++ b/examples/c-hello-world/hello.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
+#include "hello.h"
 
-int main() {
+void hello() {
     printf("Hello, world!");
-    return 0;
 }

--- a/examples/c-hello-world/hello.h
+++ b/examples/c-hello-world/hello.h
@@ -1,0 +1,1 @@
+void hello();

--- a/examples/c-hello-world/main.c
+++ b/examples/c-hello-world/main.c
@@ -1,0 +1,6 @@
+#include <hello.h>
+
+int main() {
+  hello();
+  return 0;
+}

--- a/examples/c-hello-world/project.ncl
+++ b/examples/c-hello-world/project.ncl
@@ -2,26 +2,29 @@ let inputs = import "./nickel.lock.ncl" in
 let organist = inputs.organist in
 
 {
-  packages."default" = packages.hello,
-  packages.hello =
+  flake.packages."default" = flake.packages.hello,
+  flake.packages.hello =
     organist.nix.builders.NixpkgsPkg
     & {
       name = "hello",
       version = "0.1",
-      nix_drv = {
-        buildInputs.gcc = organist.import_nix "nixpkgs#gcc",
-        buildInputs.coreutils = organist.import_nix "nixpkgs#coreutils",
-        buildInputs.bash = organist.import_nix "nixpkgs#bash",
-        buildCommand =
-          nix-s%"
-          gcc %{organist.nix.builtins.import_file "hello.c"} -o hello
-          mkdir -p $out/bin
-          cp hello $out/bin/hello
-        "%
-            | organist.nix.derivation.NixString,
+      structured_env.buildInputs = {
+        gcc = organist.import_nix "nixpkgs#gcc",
+        coreutils = organist.import_nix "nixpkgs#coreutils",
+        bash = organist.import_nix "nixpkgs#bash",
       },
+      env.src = organist.nix.builtins.import_file ".",
+      env.buildCommand =
+        nix-s%"
+          cp $src/* .
+          mkdir -p $out/{include,lib}
+          gcc -shared hello.c -o libhello.so
+          cp *.so $out/lib/
+          cp hello.h $out/include/hello.h
+        "%
+          | organist.nix.derivation.NixString,
     },
 
   shells = organist.shells.Bash,
-  shells.build.packages.hello = packages.hello,
+  shells.build.packages.hello = flake.packages.hello,
 } | organist.OrganistExpression

--- a/examples/c-hello-world/test.sh
+++ b/examples/c-hello-world/test.sh
@@ -2,4 +2,5 @@
 
 set -euo pipefail
 
-hello
+gcc -lhello main.c -o hello
+./hello

--- a/lib/nix-interop/builders.ncl
+++ b/lib/nix-interop/builders.ncl
@@ -95,7 +95,7 @@ in
           exit 1
         "%,
         env.shellHook = concat_strings_sep "\n" (std.record.values hooks),
-        structured_env.buildInputs = packages,
+        structured_env.nativeBuildInputs = packages,
       }
         | NickelPkg,
 


### PR DESCRIPTION
`nativeBuildInputs` is what we're interested in by default. In particular, this is needed to trigger the `cc` or `pkg-config` setup hooks which populate their respective search path environment variables automatically.

This is also what the Nixpkgs `mkShell` function does (probably for the same reason).

Fixes #173 