### PR TITLE
Improve the Haskell environment

### DIFF
--- a/examples/raw_nix_expression/flake.nix
+++ b/examples/raw_nix_expression/flake.nix
@@ -1,0 +1,12 @@
+{
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.organist.url = "github:nickel-lang/organist";
+
+  nixConfig = {
+    extra-substituters = ["https://organist.cachix.org"];
+    extra-trusted-public-keys = ["organist.cachix.org-1:GB9gOx3rbGl7YEh6DwOscD1+E/Gc5ZCnzqwObNH2Faw="];
+  };
+
+  outputs = {organist, ...} @ inputs:
+    organist.flake.outputsFromNickel ./. inputs {};
+}

--- a/examples/raw_nix_expression/nickel.lock.ncl
+++ b/examples/raw_nix_expression/nickel.lock.ncl
@@ -1,0 +1,3 @@
+{
+  organist = import "../../lib/organist.ncl",
+}

--- a/examples/raw_nix_expression/project.ncl
+++ b/examples/raw_nix_expression/project.ncl
@@ -1,0 +1,23 @@
+let inputs = import "./nickel.lock.ncl" in
+let organist = inputs.organist in
+
+{
+  shells = organist.shells.Bash,
+
+  shells.build = {
+    packages = {},
+  },
+
+  shells.dev = {
+    packages.python =
+      organist.nix.derivation.CallNix
+      & {
+        function = m%"
+          { python }: python.withPackages (p: [p.pyyaml])
+        "%,
+        args = {
+          python = organist.import_nix "nixpkgs#python3"
+        },
+      },
+  },
+} | organist.OrganistExpression

--- a/examples/raw_nix_expression/test.sh
+++ b/examples/raw_nix_expression/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+python3 <<<'import yaml; print(yaml.dump({"message": "Hello from python in Organist"}))'

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -118,6 +118,12 @@
           then builtins.placeholder value.output
           else if organistType == "nixToFile"
           then writeText value.name (importFromNickel_ value.text)
+          else if organistType == "callNix"
+          then let
+            fileExpr = builtins.toFile "nickel-generated-expr" (importFromNickel_ value.function);
+            importedArgs = importFromNickel_ value.args;
+          in
+            import fileExpr importedArgs
           else builtins.mapAttrs (_: importFromNickel_) value
       )
     else if (type == "list")

--- a/lib/nix-interop/derivation.ncl
+++ b/lib/nix-interop/derivation.ncl
@@ -344,4 +344,44 @@ in
       name | String,
       text | NixString,
     },
+  CallNix
+    | doc m%%"
+      Call a raw Nix expression as a function.
+
+      This will be interpreted as
+
+      ```nix
+      ${function} ${importFromNickel args}
+      ```
+
+      on the Nix side.
+
+      ## Example
+
+      ```nickel
+      organist.nix.derivation.CallNix
+      & {
+        function = m%"
+          { python }: python.withPackages (p: [p.pyyaml])
+        "%,
+        args = {
+          python = organist.import_nix "nixpkgs#python3"
+        },
+      ```
+    "%%
+    = {
+      "%{type_field}" | force = "callNix",
+      function
+        | doc m%"
+          Plain Nix expression that will be passed verbatim to the Nix evaluator.
+        "%
+        | String,
+      args
+        | doc m%"
+          Arguments that will be passed to the Nix expression.
+
+          Can be an arbitrary serializable value.
+        "%
+        | Dyn,
+    },
 }

--- a/lib/nix-interop/shells.ncl
+++ b/lib/nix-interop/shells.ncl
@@ -9,16 +9,7 @@ let concat_strings_sep = fun sep values =>
 in
 
 {
-  Bash = {
-    build =
-      builders.Shell
-      & {
-        packages = {
-          bash = nix_builtins.import_nix "nixpkgs#bash",
-        },
-      },
-    dev.packages.nickel = nix_builtins.import_nix "organist#nickel",
-  },
+  Bash = import "./shells/bash.ncl",
 
   Rust =
     Bash
@@ -106,56 +97,5 @@ in
       dev.packages.erlang-lsp = nix_builtins.import_nix "nixpkgs#erlang-ls",
     },
 
-  HaskellStack =
-    Bash
-    & {
-      build.ghcVersion
-        | doc m%"
-            The GHC version used in the build.
-            Must be kept in sync with the one expected by Stack.
-          "%
-        | String
-        | default
-        = "927",
-      build.packages =
-        let stack-wrapped =
-          {
-            name = "stack-wrapped",
-            version = "1.0",
-            build_command = {
-              cmd = nix-s%"%{nix_builtins.import_nix "nixpkgs#bash"}/bin/bash"%,
-              args = [
-                "-c",
-                nix-s%"
-                  source .attrs.sh
-                  export PATH='%{nix_builtins.import_nix "nixpkgs#coreutils"}/bin'":$PATH"
-                  mkdir -p ${outputs[out]}/bin
-                  echo "$0" > ${outputs[out]}/bin/stack
-                  chmod a+x ${outputs[out]}/bin/*
-                "%,
-                nix-s%"
-                  #!%{nix_builtins.import_nix "nixpkgs#bash"}/bin/bash
-                  %{nix_builtins.import_nix "nixpkgs#stack"}/bin/stack \
-                    --nix \
-                    --no-nix-pure \
-                    --nix-path="nixpkgs=%{nix_builtins.import_nix "nixpkgs#path"}" \
-                    "$@"
-                "%,
-              ],
-            },
-          }
-            | builders.NickelPkg
-        in
-        {
-          stack = stack-wrapped,
-          stack' = nix_builtins.import_nix "nixpkgs#stack",
-          nix = nix_builtins.import_nix "nixpkgs#nix",
-          git = nix_builtins.import_nix "nixpkgs#git",
-        },
-      dev.ghcVersion | force = build.ghcVersion,
-      dev.packages = {
-        ormolu = nix_builtins.import_nix "nixpkgs#ormolu",
-        haskell-language-server = nix_builtins.import_nix "nixpkgs#haskell.packages.ghc%{dev.ghcVersion}.haskell-language-server",
-      },
-    },
+  HaskellStack = import "./shells/haskell.ncl",
 }

--- a/lib/nix-interop/shells/bash.ncl
+++ b/lib/nix-interop/shells/bash.ncl
@@ -1,0 +1,12 @@
+let builders = import "../builders.ncl" in
+let nix_builtins = import "../builtins.ncl" in
+{
+  build =
+    builders.Shell
+    & {
+      packages = {
+        bash = nix_builtins.import_nix "nixpkgs#bash",
+      },
+    },
+  dev.packages.nickel = nix_builtins.import_nix "organist#nickel",
+}

--- a/lib/nix-interop/shells/haskell.ncl
+++ b/lib/nix-interop/shells/haskell.ncl
@@ -1,6 +1,32 @@
 let builders = import "../builders.ncl" in
+let derivation = import "../derivation.ncl" in
 let nix_builtins = import "../builtins.ncl" in
 let Bash = import "./bash.ncl" in
+
+let
+# Haskell Language Server (HLS) uses a different Ormolu version than the default one, and it's difficult to change it for now.
+# See https://github.com/haskell/haskell-language-server/issues/411
+# So we do the opposite: retrieve the Ormolu package transitively pulled by HLS.
+# Note that Ormolu is a level 2 transitive dependency of HLS: `haskell-language-server` -> `hls-ormolu-plugin` -> `ormolu`
+ormoluFromHls = fun hls =>
+  derivation.CallNix
+  & {
+    function = m%"
+      hls:
+        let
+          # Build the attrset of dependency packages of `p`
+          getDependencies = p: builtins.listToAttrs
+            (map (dependency: { name = dependency.pname; value = dependency; }) p.passthru.getBuildInputs.haskellBuildInputs);
+
+          hlsDependencies = getDependencies hls;
+          hlsOrmoluPluginDependencies = getDependencies hlsDependencies.hls-ormolu-plugin;
+        in
+        hlsOrmoluPluginDependencies.ormolu.bin
+    "%,
+    args = hls,
+  }
+in
+
 Bash
 & {
   build.ghcVersion
@@ -10,7 +36,7 @@ Bash
           "%
     | String
     | default
-    = "927",
+    = "94",
   build.packages =
     let stack-wrapped =
       {
@@ -47,8 +73,12 @@ Bash
       git = nix_builtins.import_nix "nixpkgs#git",
     },
   dev.ghcVersion | force = build.ghcVersion,
-  dev.packages = {
-    ormolu = nix_builtins.import_nix "nixpkgs#ormolu",
-    haskell-language-server = nix_builtins.import_nix "nixpkgs#haskell.packages.ghc%{dev.ghcVersion}.haskell-language-server",
-  },
+  dev.packages =
+    let ghcPackageSet =
+        "haskell.packages.ghc%{dev.ghcVersion}"
+    in
+    {
+      ormolu = ormoluFromHls haskell-language-server,
+      haskell-language-server = nix_builtins.import_nix "nixpkgs#%{ghcPackageSet}.haskell-language-server",
+    },
 }

--- a/lib/nix-interop/shells/haskell.ncl
+++ b/lib/nix-interop/shells/haskell.ncl
@@ -36,7 +36,7 @@ Bash
           "%
     | String
     | default
-    = "94",
+    = "default",
   build.packages =
     let stack-wrapped =
       {
@@ -75,6 +75,9 @@ Bash
   dev.ghcVersion | force = build.ghcVersion,
   dev.packages =
     let ghcPackageSet =
+      if dev.ghcVersion == "default" then
+        "haskellPackages"
+      else
         "haskell.packages.ghc%{dev.ghcVersion}"
     in
     {

--- a/lib/nix-interop/shells/haskell.ncl
+++ b/lib/nix-interop/shells/haskell.ncl
@@ -1,0 +1,54 @@
+let builders = import "../builders.ncl" in
+let nix_builtins = import "../builtins.ncl" in
+let Bash = import "./bash.ncl" in
+Bash
+& {
+  build.ghcVersion
+    | doc m%"
+            The GHC version used in the build.
+            Must be kept in sync with the one expected by Stack.
+          "%
+    | String
+    | default
+    = "927",
+  build.packages =
+    let stack-wrapped =
+      {
+        name = "stack-wrapped",
+        version = "1.0",
+        build_command = {
+          cmd = nix-s%"%{nix_builtins.import_nix "nixpkgs#bash"}/bin/bash"%,
+          args = [
+            "-c",
+            nix-s%"
+                  source .attrs.sh
+                  export PATH='%{nix_builtins.import_nix "nixpkgs#coreutils"}/bin'":$PATH"
+                  mkdir -p ${outputs[out]}/bin
+                  echo "$0" > ${outputs[out]}/bin/stack
+                  chmod a+x ${outputs[out]}/bin/*
+                "%,
+            nix-s%"
+                  #!%{nix_builtins.import_nix "nixpkgs#bash"}/bin/bash
+                  %{nix_builtins.import_nix "nixpkgs#stack"}/bin/stack \
+                    --nix \
+                    --no-nix-pure \
+                    --nix-path="nixpkgs=%{nix_builtins.import_nix "nixpkgs#path"}" \
+                    "$@"
+                "%,
+          ],
+        },
+      }
+        | builders.NickelPkg
+    in
+    {
+      stack = stack-wrapped,
+      stack' = nix_builtins.import_nix "nixpkgs#stack",
+      nix = nix_builtins.import_nix "nixpkgs#nix",
+      git = nix_builtins.import_nix "nixpkgs#git",
+    },
+  dev.ghcVersion | force = build.ghcVersion,
+  dev.packages = {
+    ormolu = nix_builtins.import_nix "nixpkgs#ormolu",
+    haskell-language-server = nix_builtins.import_nix "nixpkgs#haskell.packages.ghc%{dev.ghcVersion}.haskell-language-server",
+  },
+}


### PR DESCRIPTION
- Use the default haskell package set by default

    People who care about the exact version should set it anyway, and using the default one means that we get much better cache hits on the CI (so less CI time).

- Make ormolu the same version as the one used in hls

    There can be a discrepancy between `haskellPackages.ormolu` and the `ormolu` used by `haskellPackages.haskell-language-server`. Having that means that there can be a discrepancy between how the lsp will format code and how the cli tool will.

    Fix that by taking (by default) ormolu from the closure of `haskell-language-server` rather than directly from the package set.
