### PR TITLE
Create required directories for the target file

### DIFF
--- a/lib/files.ncl
+++ b/lib/files.ncl
@@ -61,6 +61,8 @@ let nix = import "./nix-interop/nix.ncl" in
           nix-s%"
             rm -f %{target}
             echo "Regenerating %{target}"
+	    target_dir=$(dirname %{target})
+	    test "${target_dir}" != "." && mkdir -p "${target_dir}"
             %{copy_command} %{file_in_store} %{target}
           "%
         in


### PR DESCRIPTION
fix for #187 

with patch:
```bash
$ fgrep files\. project.ncl 
  files."dir1/dir2/.gitignore".materialisation_method = 'Copy,
  files."dir1/dir2/.gitignore".content = m%"
$ nix run .#regenerate-files
Regenerating dir1/dir2/.gitignore
$ ls -ltr dir1/dir2/.gitignore 
-r--r--r-- 1 user user 92 mar 21 16:09 dir1/dir2/.gitignore
```