### PR TITLE
Fix deprecated nix_direnv_watch_file → watch_file

### DIFF
--- a/lib/direnv.ncl
+++ b/lib/direnv.ncl
@@ -16,7 +16,7 @@
             if ! has nix_direnv_version || ! nix_direnv_version 2.4.0; then
               source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.4.0/direnvrc" "sha256-XQzUAvL6pysIJnRJyR7uVpmUSZfc7LSgWQwq/4mBr1U="
             fi
-            nix_direnv_watch_file project.ncl nickel.lock.ncl
+            watch_file project.ncl nickel.lock.ncl
             source_env_if_exists ".envrc.private"
             use flake
           "%,


### PR DESCRIPTION
Fix deprecation message:

    `nix_direnv_watch_file` is deprecated - use `watch_file`

See [`6b44093`](https://github.com/nix-community/nix-direnv/commit/6b44093d744b2cbf720f47da9248f8bbd5ffe5aa).