### PR TITLE
chore(templates): Use fully qualified nixpkgs URL

### DIFF
--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   inputs.fenix.url = "github:nix-community/fenix";
   inputs.organist.url = "github:nickel-lang/organist";
 


### PR DESCRIPTION
This is necessary to be able to use this flake on systems with empty Nix registry.