### PR TITLE
Fix the filegen example

### DIFF
--- a/doc/filegen.md
+++ b/doc/filegen.md
@@ -5,20 +5,27 @@ Organist can be used to manage configuration files on the repository through the
 For instance:
 
 ```nickel
-let netlify_schema = import "nickel/netlify_schema.ncl" in
+let schema = import "devcontainer-schema.ncl" in
 {
-  files."netlify.toml".content = std.serialize 'Toml {
-    build.command = "gatsby build",
-    build.publish = "public/",
-  } | netlify_schema
+  files.".containers.json".content = 
+    let listen_port : Number = 3000 in
+    let config | schema = {
+      image = "ghcr.io/nixos/nix:latest",
+      forwardPorts = [listen_port],
+      containerEnv.MY_APP_LISTEN_PORT = std.to_string listen_port,
+    }
+    in
+    std.serialize 'Toml config,
 }
 ```
+
+(where `devcontainer-schema.ncl` is generated from https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.base.schema.json using https://github.com/nickel-lang/json-schema-to-nickel).
 
 This has two main advantages:
 
 1. It allows keeping everything under control (compared to a bunch of dotfiles everywhere that are easy to loose track of)
 2. It is now possible to benefit from the flexibility and safety of Nickel in these files.
-    In the example above, being able to specify a schema for the netlify config (taken from https://github.com/thufschmitt/nickel-schemastore/blob/master/out/Netlify%20config.ncl for instance) means that it's possible to get some early check and not have to wait for he CI to fail to detect a typo.
+    In the example above, being able to specify a schema for the devcontainer config means that it's possible to get some early check and not have to wait for the CI to fail to detect a typo.
 
 ## Usage
 


### PR DESCRIPTION
The file generation example in the doc was broken in two independent ways:

- The schema was applied to the wrong value (the string representing the generated TOML file instead of the corresponding record)
- The schema used didn't match what it was supposed to be (the Netlify schema on schemastore.org doesn't match the Netlify doc, I assume it's outdated).

Fix that by applying the schema at the right place, and use a schema that makes sense instead.

Also adds a small shared variable just to brag about the fact that we can do it.

Fixes #195 