### PR TITLE
Remove a useless Nixpkgs evaluation.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,13 +35,14 @@
     }:
       flake-utils.lib.eachSystem systems (system: let
         lib = self.lib.${system};
-        pkgs = nixpkgs.legacyPackages.${system};
         nickelOutputs = lib.importNcl {
           inherit baseDir flakeInputs lockFileContents;
         };
       in
         # Can't do just `{inherit nickelOutputs;} // nickelOutputs.flake` because of infinite recursion over self
-        pkgs.lib.optionalAttrs (builtins.readDir baseDir ? "project.ncl") {
+        if (! builtins.readDir baseDir ? "project.ncl")
+        then {}
+        else {
           inherit nickelOutputs;
           packages = nickelOutputs.packages or {} // nickelOutputs.flake.packages or {};
           checks = nickelOutputs.flake.checks or {};


### PR DESCRIPTION
I'm not entirely clear why, but this shoves off 20s (60%) of the evaluation time.

```console
$ hyperfine --warmup=1 -L REF HEAD,HEAD^ 'nix develop --option eval-cache false git+file://$PWD\?rev=$(git rev-parse {REF}) --command true'
Benchmark 1: nix develop --option eval-cache false git+file://$PWD\?rev=$(git rev-parse HEAD) --command true
  Time (mean ± σ):     11.693 s ±  1.475 s    [User: 4.940 s, System: 1.424 s]
  Range (min … max):   10.723 s … 14.223 s    10 runs

Benchmark 2: nix develop --option eval-cache false git+file://$PWD\?rev=$(git rev-parse HEAD^) --command true
  Time (mean ± σ):     32.296 s ±  1.090 s    [User: 15.727 s, System: 3.563 s]
  Range (min … max):   31.281 s … 34.447 s    10 runs

Summary
  nix develop --option eval-cache false git+file://$PWD\?rev=$(git rev-parse HEAD) --command true ran
    2.76 ± 0.36 times faster than nix develop --option eval-cache false git+file://$PWD\?rev=$(git rev-parse HEAD^) --command true
```