### PR TITLE
Only export the `flake` field of the nickel config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,17 +44,15 @@
         then {}
         else {
           inherit nickelOutputs;
-          packages = nickelOutputs.packages or {} // nickelOutputs.flake.packages or {};
-          checks = nickelOutputs.flake.checks or {};
+          packages = nickelOutputs.packages or {};
+          checks = nickelOutputs.checks or {};
           # Can't define this app in Nickel, yet
           apps =
             {
               regenerate-lockfile = lib.regenerateLockFileApp lockFileContents;
             }
-            // nickelOutputs.flake.apps or {};
-          # We can't just copy `shells` to `flake.devShells` in the contract
-          # because of a bug in Nickel: https://github.com/tweag/nickel/issues/1630
-          devShells = nickelOutputs.shells or {} // nickelOutputs.flake.devShells or {};
+            // nickelOutputs.apps or {};
+          devShells = nickelOutputs.devShells or {};
         });
 
     computedOutputs = outputsFromNickel ./. (inputs // {organist = self;}) {

--- a/lib/lib.nix
+++ b/lib/lib.nix
@@ -157,7 +157,7 @@
       in
       let organist = (import "${src}/nickel.lock.ncl").organist in
 
-      let nickel_expr | (organist.OrganistExpression & {..}) =
+      let nickel_expr =
         import "${src}/${nickelFile}" in
 
       nickel_expr & params
@@ -184,13 +184,13 @@
           cat > eval.ncl <<EOF
           ${nickelWithImports "sources"}
           EOF
-          ${nickel}/bin/nickel export eval.ncl > $out
+          ${nickel}/bin/nickel export eval.ncl --field config.flake > $out
         ''
       else ''
         cat > eval.ncl <<EOF
         ${nickelWithImports sources}
         EOF
-        ${nickel}/bin/nickel export eval.ncl > $out
+        ${nickel}/bin/nickel export eval.ncl --field config.flake > $out
       ''
     );
 

--- a/lib/schema.ncl
+++ b/lib/schema.ncl
@@ -64,6 +64,10 @@ let filegen = import "files.ncl" in
           | FlakeOutputs
           = {},
       },
+      config | Schema = {
+          shells,
+          flake.devShells = shells,
+        },
     }
     & filegen
 }


### PR DESCRIPTION
Makes it clear what Nix has (or not) access to.

Also makes it possible in the future to fearlessly use enums in the config, as they won't be exported

Depends on #205
