### PR TITLE
Enforce that every toplevel field of `organist` has some documentation

### DIFF
--- a/lib/modules/main.ncl
+++ b/lib/modules/main.ncl
@@ -3,11 +3,21 @@
   T
     | doc m%"
       The type of a module.
+
+      A module is a record whose contract can be extended through merging.
     "%
     = {
-      config | Schema = {},
+      config
+        | doc m%"
+          The content of the module.
+        "%
+        | Schema
+        = {},
       Schema
         | not_exported
+        | doc m%"
+          The contract that is applied to `config`.
+        "%
         = {},
       "$__organist_type" | force = "module",
     },

--- a/lib/organist.ncl
+++ b/lib/organist.ncl
@@ -1,13 +1,65 @@
 {
-  nix = import "./nix-interop/nix.ncl",
-  modules = import "./modules/main.ncl",
-  shells = nix.shells,
-  schema = import "./schema.ncl",
-  OrganistExpression = schema.OrganistExpression,
-  import_nix = nix.builtins.import_nix,
+  nix
+    | doc m%"
+      Nix interoperability library.
+    "%
+    = import "./nix-interop/nix.ncl",
+  modules
+    | doc m%"
+      implementation of a module system for Nickel, inspired by the NixOS
+      module system.
+    "%
+    = import "./modules/main.ncl",
+  shells
+    | doc m%"
+      Generic shells defined by Organist.
 
-  services = import "./services.ncl",
+      These are meant to be used as a base for the environments, and be combined or extended:
 
+      ### Example
+
+      ```nickel
+      {
+        shells = organist.shells.Bash,
+        shells = organist.shells.Rust,
+        shells.build.packages.pandoc = import_nix "nixpkgs#pandoc",
+      }
+      ```
+    "%
+    = nix.shells,
+  OrganistExpression
+    | doc m%"
+      The type of an Organist expression, defining the whole development environment.
+    "%
+    = (import "./schema.ncl").OrganistExpression,
+  import_nix
+  # XXX: That doc is duplicated from `nix-interop/builtins.ncl`.
+  # Keep it in sync, and remove once https://github.com/tweag/nickel/issues/1968 is fixed.
+    | doc m%%"
+      Import a Nix value from one of the flake inputs.
+      The value should be passed in a flakeref-like format
+      `input_name#attribute_path`.
+
+      # Example
+
+      ```nickel
+      cmd = nix-s%"%{import_nix "nixpkgs#hello"}/bin/hello > $out"%
+      ```
+    "%%
+    = nix.builtins.import_nix,
+
+  services
+    | doc m%"
+      Service management for Organist.
+
+      Merging this module with the configuration enables the `services` option.
+    "%
+    = import "./services.ncl",
+
+  tools
+    | doc m%"
+      Interface with various third-party tools.
+    "%,
   tools.editorconfig = import "./editorconfig.ncl",
   tools.direnv = import "./direnv.ncl",
 }

--- a/tests/lsp/test_completion.py
+++ b/tests/lsp/test_completion.py
@@ -107,3 +107,27 @@ organist.OrganistExpression & organist.tools.direnv
     ## No documentation for direnv yet
     # content_item = [item for item in completion_items if item.label == "direnv"][0]
     # assert content_item.documentation.value != ""
+
+@pytest.mark.asyncio
+async def test_completion_organist_lib(client: LanguageClient):
+    """
+    Make sure that everything directly exported by the library has a documentation, and that the LSP can see it
+    """
+
+    test_file = 'template/projectxx.ncl'
+    test_file_content = """
+let inputs = import "./nickel.lock.ncl" in
+let organist = inputs.organist in
+
+organist.
+    """
+
+    test_uri = open_file(client, test_file, test_file_content)
+    completion_items = await complete(
+        client,
+        test_uri,
+        lsp.Position(line=4, character=9) # End ot the last line
+    )
+    assert completion_items is not []
+    for item in completion_items:
+        assert item.documentation is not None and item.documentation.value != ""

--- a/tests/lsp/test_hover.py
+++ b/tests/lsp/test_hover.py
@@ -62,7 +62,6 @@ organist.OrganistExpression & organist.tools.direnv
             position=lsp.Position(line=8, character=28), # `content`
             checks= lambda hover_info: [
                 lsp.MarkedString_Type1(language='nickel', value='nix.derivation.NullOr nix.derivation.NixString') in hover_info.contents,
-                # Test that the contents contain a plain string (the documentation), and that it's non empty
                 next(content for content in hover_info.contents if type(content) == type("")) != "",
             ]
         ),
@@ -71,7 +70,13 @@ organist.OrganistExpression & organist.tools.direnv
             position=lsp.Position(line=10, character=11), # `shells( =)`
             checks= lambda hover_info: [
                 lsp.MarkedString_Type1(language='nickel', value='OrganistShells') in hover_info.contents,
-                # Test that the contents contain a plain string (the documentation), and that it's non empty
+                next(content for content in hover_info.contents if type(content) == type("")) != "",
+            ]
+        ),
+        HoverTest(
+            file=test_uri,
+            position=lsp.Position(line=4, character=14), # `OrganistExpression`
+            checks= lambda hover_info: [
                 next(content for content in hover_info.contents if type(content) == type("")) != "",
             ]
         ),


### PR DESCRIPTION
We can't really check the quality of the documentation (fortunately for me), but at least ensure that there's _some_ documentation for the most common things
