### PR TITLE
Close the “File” record contract

### DIFF
--- a/lib/files.ncl
+++ b/lib/files.ncl
@@ -22,8 +22,7 @@ let File = {
         might be undesirable.
       "%
     | default
-    = 'Copy,
-  ..
+    = 'Copy
 }
 in
 let Files = { _ : File }


### PR DESCRIPTION
It used to be open (probably because that was the only way to extend it before the module system), leading to some very sub-optimal error messages on something like `files.foo.connent = "blah"`.

Make it closed, so that the above properly fails with:

```
contract broken by the value of `files`
       extra field `connent`
```
