### PR TITLE
Optimize the symbolic strings contract

### DIFF
--- a/lib/nix-interop/derivation.ncl
+++ b/lib/nix-interop/derivation.ncl
@@ -165,7 +165,7 @@ in
         # We accept a single string fragment (a plain string, a derivation or a
         # Nix path). We normalize it by wrapping it as a one-element array
       else if predicate.is_string_fragment value then
-        mk_nix_string [std.contract.apply NixStringFragment label value]
+        mk_nix_string [value]
       else
         let { fragments, .. } = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,

--- a/lib/nix-interop/derivation.ncl
+++ b/lib/nix-interop/derivation.ncl
@@ -168,7 +168,12 @@ in
         mk_nix_string [value]
       else
         let { fragments, .. } = std.contract.apply NixSymbolicString label value in
-        mk_nix_string fragments,
+        mk_nix_string
+          (
+            std.array.flat_map
+              (fun elt => elt.fragments)
+              fragments
+          ),
 
   NixDerivation
     | doc m%"

--- a/lib/nix-interop/derivation.ncl
+++ b/lib/nix-interop/derivation.ncl
@@ -167,9 +167,6 @@ in
       else if predicate.is_string_fragment value then
         mk_nix_string [std.contract.apply NixStringFragment label value]
       else
-        # TODO: it's for debugging, but we should remove the serializing at some
-        # point.
-        let label = std.contract.label.append_note (std.serialize 'Json value) label in
         let { fragments, .. } = std.contract.apply NixSymbolicString label value in
         mk_nix_string fragments,
 


### PR DESCRIPTION
Optimize a bit the `SymbolicString` contract by removing some useless debug info and duplicate applications, as well as flattening all the strings as they are created.

Because this contract is used everywhere, this makes a typical Organist project (at least organist's own setup) run more than twice as fast.

| Commit                                                                                     | Mean [ms]    | Min [ms] | Max [ms] | Relative    |
|:---                                                                                        |---:          |---:      |---:      |---:         |
| `(687055c) Flatten the Nix strings on the fly`                                             | 99.5 ± 2.6   | 95.7     | 104.8    | 1.00        |
| `(0d28df8) Remove an unneeded contract application in Nix strings`                         | 113.4 ± 3.7  | 109.2    | 121.5    | 1.14 ± 0.05 |
| `(d7175d2) Remove a costly debug statement in the symbolic string contract`                | 134.7 ± 12.9 | 123.5    | 165.1    | 1.35 ± 0.13 |
| `(879ca21, main) Merge pull request #199 from ShalokShalom/patch-1`                              | 215.7 ± 8.2  | 204.1    | 230.5    | 2.17 ± 0.10 |
