### PR TITLE
Add `File.target` validation and escaping

### DIFF
--- a/lib/files.ncl
+++ b/lib/files.ncl
@@ -15,20 +15,15 @@ let NoTraversal =
       'Ok
   )
 in
-let
-# A ValidTarget eliminates these pathological targets:
-# - Empty target, i.e., "",
-# - Absolute target, e.g., `"/etc/passwd"`,
-# - Parent traversals, e.g,. `"../../../../../../../etc/passwd"`.
-ValidTarget = std.contract.all_of [std.string.NonEmpty, RelativePath, NoTraversal]
-in
 let File = {
   target
     | doc m%"
         The file to write to.
         If null, defaults to the attribute name of the file.
       "%
-    | ValidTarget
+    | std.string.NonEmpty # avoids ""
+    | RelativePath # avoids "/etc/passwd"
+    | NoTraversal # avoids "../../../../../../../etc/passwd"
     | optional,
   content
     | doc m%"

--- a/lib/files.ncl
+++ b/lib/files.ncl
@@ -3,8 +3,10 @@ let RelativePath =
   std.contract.from_predicate (fun x => !(x |> std.string.characters |> std.array.at 0 == "/"))
 in
 let NoTraversal =
-  std.contract.from_predicate (fun x => !(x |> std.string.split "/" |> std.array.any (fun part => part == ".."))
-  )
+  std.contract.from_predicate
+    (
+      fun x => !(x |> std.string.split "/" |> std.array.any (fun part => part == ".."))
+    )
 in
 let File = {
   target

--- a/lib/files.ncl
+++ b/lib/files.ncl
@@ -1,18 +1,9 @@
 let nix = import "./nix-interop/nix.ncl" in
 let RelativePath =
-  std.contract.from_validator (fun x =>
-    if x |> std.string.characters |> std.array.at 0 == "/" then
-      'Error { message = m%"Absolute Path: Expecting a relative path, got an absolute path starting with "/"."% }
-    else
-      'Ok
-  )
+  std.contract.from_predicate (fun x => !(x |> std.string.characters |> std.array.at 0 == "/"))
 in
 let NoTraversal =
-  std.contract.from_validator (fun x =>
-    if x |> std.string.split "/" |> std.array.any (fun part => part == "..") then
-      'Error { message = m%"Invalid Traversal: Path contains ".."."% }
-    else
-      'Ok
+  std.contract.from_predicate (fun x => !(x |> std.string.split "/" |> std.array.any (fun part => part == ".."))
   )
 in
 let File = {

--- a/lib/files.ncl
+++ b/lib/files.ncl
@@ -1,11 +1,34 @@
 let nix = import "./nix-interop/nix.ncl" in
+let RelativePath =
+  std.contract.from_validator (fun x =>
+    if x |> std.string.characters |> std.array.at 0 == "/" then
+      'Error { message = m%"Absolute Path: Expecting a relative path, got an absolute path starting with "/"."% }
+    else
+      'Ok
+  )
+in
+let NoTraversal =
+  std.contract.from_validator (fun x =>
+    if x |> std.string.split "/" |> std.array.any (fun part => part == "..") then
+      'Error { message = m%"Invalid Traversal: Path contains ".."."% }
+    else
+      'Ok
+  )
+in
+let
+# A ValidTarget eliminates these pathological targets:
+# - Empty target, i.e., "",
+# - Absolute target, e.g., `"/etc/passwd"`,
+# - Parent traversals, e.g,. `"../../../../../../../etc/passwd"`.
+ValidTarget = std.contract.all_of [std.string.NonEmpty, RelativePath, NoTraversal]
+in
 let File = {
   target
     | doc m%"
         The file to write to.
         If null, defaults to the attribute name of the file.
       "%
-    | String
+    | ValidTarget
     | optional,
   content
     | doc m%"
@@ -72,7 +95,12 @@ let regenerate_files | Files -> nix.derivation.Derivation
           }
             file_descr.materialisation_method
         in
-        nix-s%"regenerate_function "%{copy_command}" "%{file_descr.file}" "%{file_descr.target}""%
+        let shell_escape = fun path =>
+          path
+          |> std.string.replace "\\" "\\\\"
+          |> std.string.replace m%"""% m%"\""%
+        in
+        nix-s%"regenerate_function "%{copy_command}" "%{file_descr.file}" "%{shell_escape file_descr.target}""%
       in
     let regenerate_files = nix-s%"
       %{regenerate_function}

--- a/lib/files.ncl
+++ b/lib/files.ncl
@@ -1,11 +1,20 @@
 let nix = import "./nix-interop/nix.ncl" in
 let RelativePath =
-  std.contract.from_predicate (fun x => !(x |> std.string.characters |> std.array.at 0 == "/"))
-in
-let NoTraversal =
   std.contract.from_predicate
     (
-      fun x => !(x |> std.string.split "/" |> std.array.any (fun part => part == ".."))
+      fun x =>
+        x
+        |> std.string.characters
+        |> std.array.first != "/"
+    )
+in
+let NoParentTraversal =
+  std.contract.from_predicate
+    (
+      fun x =>
+        x
+        |> std.string.split "/"
+        |> std.array.all ((!=) "..")
     )
 in
 let File = {
@@ -16,7 +25,7 @@ let File = {
       "%
     | std.string.NonEmpty # avoids ""
     | RelativePath # avoids "/etc/passwd"
-    | NoTraversal # avoids "../../../../../../../etc/passwd"
+    | NoParentTraversal # avoids "../../../../../../../etc/passwd"
     | optional,
   content
     | doc m%"
@@ -86,9 +95,9 @@ let regenerate_files | Files -> nix.derivation.Derivation
         let shell_escape = fun path =>
           path
           |> std.string.replace "\\" "\\\\"
-          |> std.string.replace m%"""% m%"\""%
+          |> std.string.replace m%"'"% m%"\'"%
         in
-        nix-s%"regenerate_function "%{copy_command}" "%{file_descr.file}" "%{shell_escape file_descr.target}""%
+        nix-s%"regenerate_function '%{copy_command}' '%{file_descr.file}' $'%{shell_escape file_descr.target}'"%
       in
     let regenerate_files = nix-s%"
       %{regenerate_function}


### PR DESCRIPTION
This change adds these in `files.ncl`:
- `File.target` validation with `std.string.NonEmpty`, `RelativePath`, `NoParentTraversal`,
- `File.target` shell-escaping in `regenerate_one`.

Before this change, the `files` field has `File` with possibly pathological `target | String`, e.g.:
- Empty target, i.e., `""`,
- Absolute target, e.g., `"/etc/passwd"`,
- Parent traversals, e.g,. `"../../../../../../../etc/passwd"`.

This change adds schemas to eliminate such cases.

Also, in `regenerate_one`, we add `shell_escape` to `file_descr.target`:
```
nix-s%"regenerate_function '%{copy_command}' '%{file_descr.file}' $'%{shell_escape file_descr.target}'"%
```

By quoting with `$'…'` (dollar-sign and *single*-quotes) instead of `"…"` (*double*-quotes), this correctly handles paths with characters such as `"`, `'`, `*`, `\`, `\n` (newline), `\t` (tabs), `$`.